### PR TITLE
Fix events template reverting to stale 2025 data

### DIFF
--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -116,6 +116,9 @@ export async function getSchedule(year: number): Promise<ScheduleRace[]> {
   if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
   const data = await res.json() as any;
   const races = data.MRData.RaceTable.Races as ScheduleRace[];
+  if (!races || races.length === 0) {
+    throw new Error(`Ergast API returned no races for ${year}`);
+  }
   return races.map(race => {
     if (race.raceName === 'Brazilian Grand Prix' && year >= 2021) {
       return { ...race, raceName: 'São Paulo Grand Prix' };
@@ -125,6 +128,27 @@ export async function getSchedule(year: number): Promise<ScheduleRace[]> {
     }
     return race;
   });
+}
+
+export async function getScheduleWithRetry(
+  year: number,
+  attempts = 3,
+  delayMs = 1000
+): Promise<ScheduleRace[]> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await getSchedule(year);
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        const backoff = delayMs * attempt;
+        console.warn(`getSchedule(${year}) attempt ${attempt} failed, retrying in ${backoff}ms...`, error);
+        await new Promise(resolve => setTimeout(resolve, backoff));
+      }
+    }
+  }
+  throw lastError;
 }
 
 // Fetch race results

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { frontendHtml } from './frontend-html';
 import { 
-  getSchedule, 
+  getSchedule,
+  getScheduleWithRetry,
   getRaceResult, 
   getQualifyingResult, 
   getDriverStandings, 
@@ -1430,6 +1431,8 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
   }
 }
 
+const ACTIVE_SEASON = 2026;
+
 async function syncLatestNewsEvents(env: any, getSession: () => Promise<any>): Promise<void> {
   const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
   const apiEndpoint = env.WIKI_API_ENDPOINT;
@@ -1438,13 +1441,26 @@ async function syncLatestNewsEvents(env: any, getSession: () => Promise<any>): P
   console.log("Starting latest news events sync...");
 
   try {
-    const currentYear = new Date().getFullYear();
-    console.log(`Fetching schedules for ${currentYear - 1}, ${currentYear}, and ${currentYear + 1}...`);
-    
-    const [prevSchedule, currentSchedule, nextSchedule] = await Promise.all([
-      getSchedule(currentYear - 1).catch(() => []),
-      getSchedule(currentYear).catch(() => []),
-      getSchedule(currentYear + 1).catch(() => [])
+    const seasonYear = ACTIVE_SEASON;
+    console.log(`Fetching schedules for ${seasonYear - 1}, ${seasonYear}, and ${seasonYear + 1}...`);
+
+    let currentSchedule: Awaited<ReturnType<typeof getSchedule>> = [];
+    try {
+      currentSchedule = await getScheduleWithRetry(seasonYear);
+    } catch (error) {
+      console.error(`Failed to load ${seasonYear} schedule after retries. Skipping events sync to avoid stale data.`, error);
+      return;
+    }
+
+    const [prevSchedule, nextSchedule] = await Promise.all([
+      getSchedule(seasonYear - 1).catch((error) => {
+        console.warn(`Failed to load ${seasonYear - 1} schedule (non-fatal):`, error);
+        return [];
+      }),
+      getSchedule(seasonYear + 1).catch((error) => {
+        console.warn(`Failed to load ${seasonYear + 1} schedule (non-fatal):`, error);
+        return [];
+      })
     ]);
 
     const mergedSchedule = [...prevSchedule, ...currentSchedule, ...nextSchedule];
@@ -1494,6 +1510,20 @@ async function syncLatestNewsEvents(env: any, getSession: () => Promise<any>): P
     }
 
     const isLatestOngoing = ongoingEvents.length > 0;
+
+    const hasConcludedCurrentSeasonRace = events.some(
+      e => String(e.year) === String(seasonYear) && e.endTime < now
+    );
+    if (
+      hasConcludedCurrentSeasonRace &&
+      latestEvent &&
+      Number(latestEvent.year) < seasonYear
+    ) {
+      console.error(
+        `Sanity check failed: ${seasonYear} has concluded races but latest event resolved to ${latestEvent.year} ${latestEvent.fullName}. Skipping edit to avoid reverting to stale data.`
+      );
+      return;
+    }
 
     console.log("Calculated events:", {
       previous: previousEvent ? `${previousEvent.year} ${previousEvent.fullName}` : 'None',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`Template:Latest_F1_News/Events` was flip-flopping between correct 2026 data and stale 2025 data (Qatar / Abu Dhabi, with no next event).

## Root cause

`syncLatestNewsEvents` fetched schedules for three years in parallel and used `.catch(() => [])` on all of them. When the Jolpi API call for the active season (2026) failed intermittently, the sync continued with only 2025 races. That made Abu Dhabi 2025 the "latest" event and dropped the next-event line entirely. On the next hourly run, when the 2026 fetch succeeded again, the template reverted to the correct values — producing a no-op edit cycle.

## Fix

- Add `getScheduleWithRetry()` with exponential backoff for schedule fetches.
- Require a successful active-season (`2026`) schedule before publishing; skip the sync entirely if it cannot be loaded.
- Treat prior/next season schedule failures as non-fatal (they are only needed for context).
- Add a sanity check: if the current season already has concluded races but the resolved latest event is still from a prior season, skip the wiki edit.

## Testing

- `tsc --noEmit` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec0cea5c-2cf2-4b99-b59c-ccff68c6b4f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec0cea5c-2cf2-4b99-b59c-ccff68c6b4f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

