### PR TITLE
Reduce Jolpica API usage with per-run cache and 429 backoff

### DIFF
--- a/scripts/verify-jolpica-cache.ts
+++ b/scripts/verify-jolpica-cache.ts
@@ -1,0 +1,101 @@
+/**
+ * Verifies within-run Jolpica cache deduplication and 429 backoff.
+ * Run: npx tsx scripts/verify-jolpica-cache.ts
+ */
+import { createF1ApiContext } from '../src/f1-api-cache';
+import { getSchedule, getRaceResult } from '../src/f1-api';
+
+let fetchCount = 0;
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  fetchCount++;
+  const url = String(input);
+
+  if (url.includes('429-test')) {
+    return new Response('throttled', { status: 429, headers: { 'Retry-After': '1' } });
+  }
+
+  if (url.includes('/2026.json')) {
+    return new Response(JSON.stringify({
+      MRData: {
+        RaceTable: {
+          Races: [{ season: '2026', round: '1', raceName: 'Test GP', Circuit: { circuitId: 'test', circuitName: 'Test', Location: { locality: 'X', country: 'Y' } }, date: '2026-01-01' }]
+        }
+      }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  if (url.includes('/results.json')) {
+    return new Response(JSON.stringify({
+      MRData: { RaceTable: { Races: [{ Results: [] }] } }
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  return originalFetch(input, init);
+};
+
+async function testScheduleDedup() {
+  fetchCount = 0;
+  const ctx = createF1ApiContext();
+  await getSchedule(2026, ctx);
+  await getSchedule(2026, ctx);
+  await getSchedule(2026, ctx);
+  if (fetchCount !== 1) {
+    throw new Error(`Expected 1 fetch for 3 getSchedule calls, got ${fetchCount}`);
+  }
+  console.log('PASS: schedule dedup (3 calls -> 1 fetch)');
+}
+
+async function testRaceResultDedup() {
+  fetchCount = 0;
+  const ctx = createF1ApiContext();
+  await Promise.all([
+    getRaceResult(2026, 1, false, ctx),
+    getRaceResult(2026, 1, false, ctx),
+  ]);
+  if (fetchCount !== 1) {
+    throw new Error(`Expected 1 fetch for 2 concurrent getRaceResult calls, got ${fetchCount}`);
+  }
+  console.log('PASS: race result in-flight dedup');
+}
+
+async function test429Backoff() {
+  fetchCount = 0;
+  const ctx = createF1ApiContext();
+  const start = Date.now();
+  // Temporarily override fetch for 429 scenario
+  const prev = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    if (calls <= 2) {
+      return new Response('throttled', { status: 429, headers: { 'Retry-After': '1' } });
+    }
+    return new Response(JSON.stringify({
+      MRData: { RaceTable: { Races: [{ season: '2026', round: '1', raceName: 'Test GP', date: '2026-01-01' }] } }
+    }), { status: 200 });
+  };
+
+  try {
+    await getSchedule(2026, ctx);
+    const elapsed = Date.now() - start;
+    if (calls < 3) throw new Error(`Expected at least 3 attempts on 429, got ${calls}`);
+    if (elapsed < 1000) throw new Error(`Expected backoff delay >= 1s, got ${elapsed}ms`);
+    console.log(`PASS: 429 backoff (${calls} attempts, ${elapsed}ms elapsed)`);
+  } finally {
+    globalThis.fetch = prev;
+  }
+}
+
+async function main() {
+  await testScheduleDedup();
+  await testRaceResultDedup();
+  await test429Backoff();
+  console.log('All Jolpica cache verification tests passed.');
+}
+
+main().catch(err => {
+  console.error('FAIL:', err.message);
+  process.exit(1);
+});

--- a/src/f1-api-cache.ts
+++ b/src/f1-api-cache.ts
@@ -1,0 +1,149 @@
+/**
+ * Within-run Jolpica API cache with in-flight deduplication and 429 backoff.
+ * Create one context per cron invocation (or per HTTP request) and pass it through.
+ */
+
+const MAX_RETRIES = 4;
+const BASE_BACKOFF_MS = 2000;
+
+export interface F1ApiContext {
+  readonly cache: Map<string, unknown>;
+  readonly inFlight: Map<string, Promise<unknown>>;
+  apiCallCount: number;
+}
+
+export function createF1ApiContext(): F1ApiContext {
+  return {
+    cache: new Map(),
+    inFlight: new Map(),
+    apiCallCount: 0,
+  };
+}
+
+function parseRetryAfterMs(retryAfter: string | null): number | null {
+  if (!retryAfter) return null;
+  const asSeconds = Number(retryAfter);
+  if (!Number.isNaN(asSeconds) && asSeconds >= 0) {
+    return asSeconds * 1000;
+  }
+  const asDate = Date.parse(retryAfter);
+  if (!Number.isNaN(asDate)) {
+    return Math.max(0, asDate - Date.now());
+  }
+  return null;
+}
+
+function backoffDelayMs(attempt: number, retryAfter: string | null): number {
+  const fromHeader = parseRetryAfterMs(retryAfter);
+  if (fromHeader !== null) {
+    return Math.min(fromHeader, 60_000);
+  }
+  return Math.min(BASE_BACKOFF_MS * 2 ** (attempt - 1), 30_000);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Fetch from Jolpica with per-run caching, dedup, and 429 backoff. */
+export async function fetchJolpica(url: string, ctx?: F1ApiContext): Promise<Response> {
+  if (!ctx) {
+    return fetchJolpicaUncached(url);
+  }
+
+  const cached = ctx.cache.get(url);
+  if (cached instanceof Response) {
+    return cached.clone();
+  }
+
+  const existing = ctx.inFlight.get(url);
+  if (existing) {
+    const res = await existing as Response;
+    return res.clone();
+  }
+
+  const promise = fetchJolpicaUncached(url, ctx);
+  ctx.inFlight.set(url, promise);
+
+  try {
+    const res = await promise;
+    if (res.ok) {
+      ctx.cache.set(url, res.clone());
+    }
+    return res;
+  } finally {
+    ctx.inFlight.delete(url);
+  }
+}
+
+async function fetchJolpicaUncached(url: string, ctx?: F1ApiContext): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    if (ctx) ctx.apiCallCount++;
+
+    const res = await fetch(url);
+
+    if (res.status === 429) {
+      const retryAfter = res.headers.get('Retry-After');
+      lastError = new Error(`Ergast API error: Too Many Requests`);
+      if (attempt < MAX_RETRIES) {
+        const delay = backoffDelayMs(attempt, retryAfter);
+        console.warn(
+          `Jolpica 429 on ${url} (attempt ${attempt}/${MAX_RETRIES}), backing off ${delay}ms...`
+        );
+        await sleep(delay);
+        continue;
+      }
+      throw lastError;
+    }
+
+    if (!res.ok) {
+      throw new Error(`Ergast API error: ${res.statusText}`);
+    }
+
+    return res;
+  }
+
+  throw lastError ?? new Error('Ergast API error: Too Many Requests');
+}
+
+/** Run a cached JSON fetch; deduplicates concurrent requests for the same URL. */
+export async function cachedJolpicaJson<T>(
+  url: string,
+  ctx: F1ApiContext | undefined,
+  parse: (data: unknown) => T
+): Promise<T> {
+  if (ctx) {
+    const cached = ctx.cache.get(url);
+    if (cached !== undefined && !(cached instanceof Response)) {
+      return cached as T;
+    }
+
+    const existing = ctx.inFlight.get(url);
+    if (existing) {
+      return existing as Promise<T>;
+    }
+  }
+
+  const promise = (async () => {
+    const res = await fetchJolpica(url, ctx);
+    const data = await res.json();
+    const parsed = parse(data);
+    if (ctx) {
+      ctx.cache.set(url, parsed);
+    }
+    return parsed;
+  })();
+
+  if (ctx) {
+    ctx.inFlight.set(url, promise);
+    try {
+      return await promise;
+    } finally {
+      ctx.inFlight.delete(url);
+    }
+  }
+
+  return promise;
+}

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -1,3 +1,7 @@
+import { cachedJolpicaJson, createF1ApiContext, F1ApiContext } from './f1-api-cache';
+
+export { createF1ApiContext, F1ApiContext };
+
 export interface Driver {
   driverId: string;
   permanentNumber: string;
@@ -109,16 +113,7 @@ export interface PracticeResults {
 
 const BASE_URL = 'https://api.jolpi.ca/ergast/f1';
 
-// Fetch season schedule
-export async function getSchedule(year: number): Promise<ScheduleRace[]> {
-  const url = `${BASE_URL}/${year}.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  const races = data.MRData.RaceTable.Races as ScheduleRace[];
-  if (!races || races.length === 0) {
-    throw new Error(`Ergast API returned no races for ${year}`);
-  }
+function normalizeScheduleRaces(races: ScheduleRace[], year: number): ScheduleRace[] {
   return races.map(race => {
     if (race.raceName === 'Brazilian Grand Prix' && year >= 2021) {
       return { ...race, raceName: 'São Paulo Grand Prix' };
@@ -130,11 +125,32 @@ export async function getSchedule(year: number): Promise<ScheduleRace[]> {
   });
 }
 
+function scheduleCacheKey(year: number): string {
+  return `${BASE_URL}/${year}.json?limit=1000`;
+}
+
+// Fetch season schedule
+export async function getSchedule(year: number, ctx?: F1ApiContext): Promise<ScheduleRace[]> {
+  const url = scheduleCacheKey(year);
+  return cachedJolpicaJson(url, ctx, (data: any) => {
+    const list = data.MRData.RaceTable.Races as ScheduleRace[];
+    if (!list || list.length === 0) {
+      throw new Error(`Ergast API returned no races for ${year}`);
+    }
+    return normalizeScheduleRaces(list, year);
+  });
+}
+
 export async function getScheduleWithRetry(
   year: number,
   attempts = 3,
-  delayMs = 1000
+  delayMs = 1000,
+  ctx?: F1ApiContext
 ): Promise<ScheduleRace[]> {
+  if (ctx) {
+    return getSchedule(year, ctx);
+  }
+
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
@@ -151,30 +167,35 @@ export async function getScheduleWithRetry(
   throw lastError;
 }
 
-// Fetch race results
-export async function getRaceResult(year: number, round: number, isSprint = false): Promise<RaceResult[]> {
-  const endpoint = isSprint ? 'sprint' : 'results';
-  const url = `${BASE_URL}/${year}/${round}/${endpoint}.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  
-  const races = data.MRData.RaceTable.Races;
-  if (!races || races.length === 0) return [];
-  
-  const resultsKey = isSprint ? 'SprintResults' : 'Results';
-  const rawResults = races[0][resultsKey] || [];
-  const results = rawResults.map((r: any) => ({
+function mapRaceResults(rawResults: any[]): RaceResult[] {
+  return rawResults.map((r: any) => ({
     ...r,
     driver: r.Driver,
     constructor: r.Constructor
   }));
+}
 
-  // Fallback to qualifying results if grid values are null/undefined
+// Fetch race results
+export async function getRaceResult(
+  year: number,
+  round: number,
+  isSprint = false,
+  ctx?: F1ApiContext
+): Promise<RaceResult[]> {
+  const endpoint = isSprint ? 'sprint' : 'results';
+  const url = `${BASE_URL}/${year}/${round}/${endpoint}.json?limit=1000`;
+
+  const results = await cachedJolpicaJson(url, ctx, (data: any) => {
+    const races = data.MRData.RaceTable.Races;
+    if (!races || races.length === 0) return [];
+    const resultsKey = isSprint ? 'SprintResults' : 'Results';
+    return mapRaceResults(races[0][resultsKey] || []);
+  });
+
   const hasNullGrid = results.some((r: any) => r.grid === null || r.grid === undefined);
   if (hasNullGrid) {
     try {
-      const qualiResults = await getQualifyingResult(year, round);
+      const qualiResults = await getQualifyingResult(year, round, ctx);
       if (qualiResults && qualiResults.length > 0) {
         const qualiMap = new Map<string, string>();
         qualiResults.forEach((q: any) => {
@@ -200,75 +221,86 @@ export async function getRaceResult(year: number, round: number, isSprint = fals
 }
 
 // Fetch qualifying results
-export async function getQualifyingResult(year: number, round: number): Promise<QualifyingResult[]> {
+export async function getQualifyingResult(
+  year: number,
+  round: number,
+  ctx?: F1ApiContext
+): Promise<QualifyingResult[]> {
   const url = `${BASE_URL}/${year}/${round}/qualifying.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  
-  const races = data.MRData.RaceTable.Races;
-  if (!races || races.length === 0) return [];
-  const rawResults = races[0].QualifyingResults || [];
-  return rawResults.map((q: any) => ({
-    ...q,
-    driver: q.Driver,
-    constructor: q.Constructor
-  }));
+  return cachedJolpicaJson(url, ctx, (data: any) => {
+    const races = data.MRData.RaceTable.Races;
+    if (!races || races.length === 0) return [];
+    const rawResults = races[0].QualifyingResults || [];
+    return rawResults.map((q: any) => ({
+      ...q,
+      driver: q.Driver,
+      constructor: q.Constructor
+    }));
+  });
 }
 
 // Fetch driver standings
-export async function getDriverStandings(year: number, round?: number): Promise<DriverStanding[]> {
+export async function getDriverStandings(
+  year: number,
+  round?: number,
+  ctx?: F1ApiContext
+): Promise<DriverStanding[]> {
   const suffix = round ? `/${round}` : '';
   const url = `${BASE_URL}/${year}${suffix}/driverStandings.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  
-  const lists = data.MRData.StandingsTable.StandingsLists;
-  if (!lists || lists.length === 0) return [];
-  return lists[0].DriverStandings || [];
+  return cachedJolpicaJson(url, ctx, (data: any) => {
+    const lists = data.MRData.StandingsTable.StandingsLists;
+    if (!lists || lists.length === 0) return [];
+    return lists[0].DriverStandings || [];
+  });
 }
 
 // Fetch constructor standings
-export async function getConstructorStandings(year: number, round?: number): Promise<ConstructorStanding[]> {
+export async function getConstructorStandings(
+  year: number,
+  round?: number,
+  ctx?: F1ApiContext
+): Promise<ConstructorStanding[]> {
   const suffix = round ? `/${round}` : '';
   const url = `${BASE_URL}/${year}${suffix}/constructorStandings.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  
-  const lists = data.MRData.StandingsTable.StandingsLists;
-  if (!lists || lists.length === 0) return [];
-  return lists[0].ConstructorStandings || [];
+  return cachedJolpicaJson(url, ctx, (data: any) => {
+    const lists = data.MRData.StandingsTable.StandingsLists;
+    if (!lists || lists.length === 0) return [];
+    return lists[0].ConstructorStandings || [];
+  });
 }
 
 // Fetch list of drivers for a race (to initialize practice entries)
-export async function getDriversForRace(year: number, round: number): Promise<Driver[]> {
+export async function getDriversForRace(
+  year: number,
+  round: number,
+  ctx?: F1ApiContext
+): Promise<Driver[]> {
   const url = `${BASE_URL}/${year}/${round}/drivers.json?limit=1000`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`Ergast API error: ${res.statusText}`);
-  const data = await res.json() as any;
-  return data.MRData.DriverTable.Drivers || [];
+  return cachedJolpicaJson(url, ctx, (data: any) => data.MRData.DriverTable.Drivers || []);
 }
 
 // Fetch list of drivers for a race, with recursive fallback to preceding races/seasons if empty
-export async function getDriversForRaceWithFallback(year: number, round: number): Promise<Driver[]> {
-  let drivers = await getDriversForRace(year, round).catch(() => []);
+export async function getDriversForRaceWithFallback(
+  year: number,
+  round: number,
+  ctx?: F1ApiContext
+): Promise<Driver[]> {
+  let drivers = await getDriversForRace(year, round, ctx).catch(() => []);
   let currentYear = year;
   let prevRound = round - 1;
-  
+
   while (drivers.length === 0) {
     if (prevRound >= 1) {
-      drivers = await getDriversForRace(currentYear, prevRound).catch(() => []);
+      drivers = await getDriversForRace(currentYear, prevRound, ctx).catch(() => []);
       prevRound--;
     } else {
       currentYear--;
       try {
-        const prevSchedule = await getSchedule(currentYear);
+        const prevSchedule = await getSchedule(currentYear, ctx);
         if (prevSchedule && prevSchedule.length > 0) {
           prevRound = prevSchedule.length;
         } else {
-          break; // Avoid infinite loop if no more schedules
+          break;
         }
       } catch (e) {
         break;
@@ -278,63 +310,69 @@ export async function getDriversForRaceWithFallback(year: number, round: number)
   return drivers;
 }
 
+/** Fetch lap chart data for a round (used by stats). */
+export async function getLapChart(
+  year: number,
+  round: number,
+  ctx?: F1ApiContext
+): Promise<Array<{ Timings: Array<{ driverId: string }> }>> {
+  const url = `${BASE_URL}/${year}/${round}/laps.json?limit=2000`;
+  return cachedJolpicaJson(url, ctx, (data: any) => {
+    const races = data?.MRData?.RaceTable?.Races || data?.MRData?.LapsTable?.Races || [];
+    return races[0]?.Laps || [];
+  });
+}
+
 // Parse HTML string from F1.com practice session results
 export function parsePracticeHTML(html: string): Record<string, PracticeSessionData> {
   const results: Record<string, PracticeSessionData> = {};
-  
-  // Find table rows
+
   const trRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
   const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
-  
+
   let trMatch;
   while ((trMatch = trRegex.exec(html)) !== null) {
     const rowHtml = trMatch[1];
     const cells: string[] = [];
     let tdMatch;
-    
+
     while ((tdMatch = tdRegex.exec(rowHtml)) !== null) {
-      // Strip tags and clean whitespace
       const cleanCell = tdMatch[1]
         .replace(/<[^>]*>/g, '')
         .replace(/\s+/g, ' ')
         .trim();
       cells.push(cleanCell);
     }
-    
-    // Check if the row has enough columns (typically 5-7 columns)
-    // Pos, No, Driver, Car/Team, Time, Gap, Laps
+
     if (cells.length >= 5) {
       const position = cells[0];
       const number = cells[1];
       const rawDriverName = cells[2];
       const teamName = cells[3];
       const time = cells[4];
-      
-      // If position is not a number, skip header/footer rows
+
       if (/^\d+$/.test(position)) {
         results[rawDriverName] = {
           position,
           number,
-          driverName: rawDriverName, // will be mapped later
+          driverName: rawDriverName,
           teamName,
           time
         };
       }
     }
   }
-  
+
   return results;
 }
 
-// Map practice results using fetched drivers to resolve name formats (e.g. LandoNorrisNOR -> Lando Norris)
+// Map practice results using fetched drivers to resolve name formats
 export function mapDriverNames(
   scrapedData: Record<string, PracticeSessionData>,
   drivers: Driver[]
 ): Record<string, PracticeSessionData> {
   const mappedResults: Record<string, PracticeSessionData> = {};
-  
-  // Create mapping keys from official drivers
-  // E.g. Lando Norris (code: NOR) -> LandoNorrisNOR
+
   const mapping: Record<string, Driver> = {};
   for (const driver of drivers) {
     const key1 = `${driver.givenName}${driver.familyName}${driver.code}`.replace(/[\s'-]/g, '');
@@ -344,8 +382,7 @@ export function mapDriverNames(
     mapping[driver.driverId.toLowerCase()] = driver;
     mapping[`${driver.givenName} ${driver.familyName}`.toLowerCase()] = driver;
   }
-  
-  // Fallback map for common outliers
+
   const customMapping: Record<string, string> = {
     'nico hulkenberg': 'Nico Hülkenberg',
     'nicohulkenberghul': 'Nico Hülkenberg',
@@ -359,12 +396,11 @@ export function mapDriverNames(
 
   for (const [rawName, data] of Object.entries(scrapedData)) {
     const cleanKey = rawName.replace(/[\s'-]/g, '').toLowerCase();
-    
+
     let matchedDriver: Driver | null = null;
     if (mapping[cleanKey]) {
       matchedDriver = mapping[cleanKey];
     } else {
-      // Try to find if any key contains the driver name
       for (const [key, driver] of Object.entries(mapping)) {
         if (cleanKey.includes(key) || key.includes(cleanKey)) {
           matchedDriver = driver;
@@ -372,12 +408,11 @@ export function mapDriverNames(
         }
       }
     }
-    
+
     let resolvedName = rawName;
     if (matchedDriver) {
       resolvedName = `${matchedDriver.givenName} ${matchedDriver.familyName}`;
     } else {
-      // Check custom mapping
       const keyLower = rawName.toLowerCase();
       for (const [k, v] of Object.entries(customMapping)) {
         if (keyLower.includes(k) || k.includes(keyLower)) {
@@ -386,13 +421,13 @@ export function mapDriverNames(
         }
       }
     }
-    
+
     mappedResults[resolvedName] = {
       ...data,
       driverName: resolvedName
     };
   }
-  
+
   return mappedResults;
 }
 
@@ -403,11 +438,11 @@ export async function scrapePracticeSession(url: string, drivers: Driver[]): Pro
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
     'Accept-Language': 'en-US,en;q=0.5',
   };
-  
+
   const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`Failed to fetch F1.com practice page: Status ${res.status}`);
   const html = await res.text();
-  
+
   const parsed = parsePracticeHTML(html);
   return mapDriverNames(parsed, drivers);
 }
@@ -467,22 +502,86 @@ export async function fetchOfficialRaceName(year: number, racingKey: string): Pr
     });
     if (!res.ok) return null;
     const html = await res.text();
-    
-    // Extract schema SportsEvent name, e.g., "name":"FORMULA 1 LOUIS VUITTON GRAND PRIX DE MONACO 2026"
+
     const nameMatch = html.match(/"@type"\s*:\s*"SportsEvent"[^}]+?"name"\s*:\s*"([^"]+)"/);
     if (nameMatch && nameMatch[1]) {
       return cleanOfficialName(nameMatch[1]);
     }
-    
-    // Fallback: title tag
+
     const titleMatch = html.match(/<title>([^<]+)<\/title>/i);
     if (titleMatch && titleMatch[1]) {
       return cleanOfficialName(titleMatch[1].replace(" - F1 Race", "").trim());
     }
-    
+
     return null;
   } catch (e) {
     console.error("Error fetching official race name:", e);
     return null;
   }
+}
+
+/**
+ * Batch-fetch Jolpica data for a race round in one pass (deduplicated via ctx).
+ */
+export async function fetchRoundJolpicaData(
+  year: number,
+  round: number,
+  options: {
+    needQuali: boolean;
+    needGpResults: boolean;
+    needSprintResults: boolean;
+    needStandings: boolean;
+    needDrivers: boolean;
+    hasSprint: boolean;
+  },
+  ctx?: F1ApiContext
+): Promise<{
+  qualiResults: QualifyingResult[];
+  gpResults: RaceResult[];
+  sprintResults: RaceResult[];
+  drivers: Driver[];
+  currentDrivers: DriverStanding[];
+  prevDrivers: DriverStanding[] | null;
+  currentConstructors: ConstructorStanding[];
+  prevConstructors: ConstructorStanding[] | null;
+}> {
+  const {
+    needQuali,
+    needGpResults,
+    needSprintResults,
+    needStandings,
+    needDrivers,
+    hasSprint,
+  } = options;
+
+  const [
+    qualiResults,
+    gpResults,
+    sprintResults,
+    currentDrivers,
+    prevDrivers,
+    currentConstructors,
+    prevConstructors,
+    drivers,
+  ] = await Promise.all([
+    needQuali ? getQualifyingResult(year, round, ctx).catch(() => []) : Promise.resolve([]),
+    needGpResults ? getRaceResult(year, round, false, ctx).catch(() => []) : Promise.resolve([]),
+    needSprintResults && hasSprint ? getRaceResult(year, round, true, ctx).catch(() => []) : Promise.resolve([]),
+    needStandings ? getDriverStandings(year, round, ctx).catch(() => []) : Promise.resolve([]),
+    needStandings && round > 1 ? getDriverStandings(year, round - 1, ctx).catch(() => null) : Promise.resolve(null),
+    needStandings ? getConstructorStandings(year, round, ctx).catch(() => []) : Promise.resolve([]),
+    needStandings && round > 1 ? getConstructorStandings(year, round - 1, ctx).catch(() => null) : Promise.resolve(null),
+    needDrivers ? getDriversForRaceWithFallback(year, round, ctx).catch(() => []) : Promise.resolve([]),
+  ]);
+
+  return {
+    qualiResults,
+    gpResults,
+    sprintResults,
+    drivers,
+    currentDrivers,
+    prevDrivers,
+    currentConstructors,
+    prevConstructors,
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { frontendHtml } from './frontend-html';
 import { 
   getSchedule,
-  getScheduleWithRetry,
   getRaceResult, 
   getQualifyingResult, 
   getDriverStandings, 
@@ -11,7 +10,11 @@ import {
   parsePracticeHTML,
   mapDriverNames,
   fetchOfficialRaceName,
-  getF1RacingKey
+  getF1RacingKey,
+  createF1ApiContext,
+  fetchRoundJolpicaData,
+  F1ApiContext,
+  ScheduleRace,
 } from './f1-api';
 import { 
   generateGridWikitext, 
@@ -113,6 +116,8 @@ export default {
     }
 
     try {
+      const apiCtx = createF1ApiContext();
+
       // 1. Serve SPA Frontend
       if (url.pathname === '/' || url.pathname === '/index.html') {
         const siteKey = _env.TURNSTILE_SITE_KEY || "0x4AAAAAABoDGtBnq2BXlSqW";
@@ -128,7 +133,7 @@ export default {
         if (!yearStr) return corsResponse({ error: 'Year parameter required' }, 400);
         
         const year = parseInt(yearStr, 10);
-        const schedule = await getSchedule(year);
+        const schedule = await getSchedule(year, apiCtx);
         return corsResponse({ schedule });
       }
 
@@ -144,13 +149,13 @@ export default {
         const year = parseInt(yearStr, 10);
         const round = parseInt(roundStr, 10);
         
-        const schedule = await getSchedule(year);
+        const schedule = await getSchedule(year, apiCtx);
         const race = schedule.find(r => parseInt(r.round, 10) === round);
         if (!race) {
           return corsResponse({ error: `Round ${round} not found in schedule` }, 404);
         }
         
-        const drivers = await getDriversForRaceWithFallback(year, round);
+        const drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
         
         const racingKey = getF1RacingKey(race.raceName);
         const officialName = await fetchOfficialRaceName(year, racingKey).catch(() => null);
@@ -181,19 +186,19 @@ export default {
           currentConstructors,
           prevConstructors,
         ] = await Promise.all([
-          getDriversForRaceWithFallback(year, round),
-          getRaceResult(year, round, false).catch(() => []),
-          getQualifyingResult(year, round).catch(() => []),
-          getDriverStandings(year, round).catch(() => []),
-          round > 1 ? getDriverStandings(year, round - 1).catch(() => null) : Promise.resolve(null),
-          getConstructorStandings(year, round).catch(() => []),
-          round > 1 ? getConstructorStandings(year, round - 1).catch(() => null) : Promise.resolve(null),
+          getDriversForRaceWithFallback(year, round, apiCtx),
+          getRaceResult(year, round, false, apiCtx).catch(() => []),
+          getQualifyingResult(year, round, apiCtx).catch(() => []),
+          getDriverStandings(year, round, apiCtx).catch(() => []),
+          round > 1 ? getDriverStandings(year, round - 1, apiCtx).catch(() => null) : Promise.resolve(null),
+          getConstructorStandings(year, round, apiCtx).catch(() => []),
+          round > 1 ? getConstructorStandings(year, round - 1, apiCtx).catch(() => null) : Promise.resolve(null),
         ]);
 
         // Sprint is optional, query it separately
         let sprintResults: any[] = [];
         try {
-          sprintResults = await getRaceResult(year, round, true);
+          sprintResults = await getRaceResult(year, round, true, apiCtx);
         } catch (e) {
           // No sprint race
         }
@@ -242,8 +247,8 @@ export default {
         const yr = parseInt(year, 10);
         const rd = parseInt(round, 10);
 
-        const drivers = await getDriversForRaceWithFallback(yr, rd);
-        const qualiResults = await getQualifyingResult(yr, rd).catch(() => null);
+        const drivers = await getDriversForRaceWithFallback(yr, rd, apiCtx);
+        const qualiResults = await getQualifyingResult(yr, rd, apiCtx).catch(() => null);
 
         // Fallback Only: empty table
         if (fallbackOnly) {
@@ -380,10 +385,10 @@ export default {
           
           // Run Jolpi API fetch, StatsF1 classification fetch, schedule fetch, and cumulative stats calculation concurrently
           const [cumulativeStats, jolpiResults, statsF1Results, schedule] = await Promise.all([
-            get2026CumulativeStats(_env, round, forceRefresh),
-            getRaceResult(2026, round, false).catch(() => []),
+            get2026CumulativeStats(_env, round, forceRefresh, apiCtx),
+            getRaceResult(2026, round, false, apiCtx).catch(() => []),
             getStatsF1Results(round).catch(() => null),
-            getSchedule(2026).catch(() => [])
+            getSchedule(2026, apiCtx).catch(() => [])
           ]);
           
           const race = schedule.find((r: any) => parseInt(r.round, 10) === round);
@@ -487,16 +492,16 @@ export default {
 
           const rd = parseInt(round, 10);
           console.log(`Calculating cumulative stats up to round ${rd} for publishing...`);
-          const cumulativeStats = await get2026CumulativeStats(_env, rd);
+          const cumulativeStats = await get2026CumulativeStats(_env, rd, false, apiCtx);
 
           // Get latest race info for correction text update
-          const schedule = await getSchedule(2026);
+          const schedule = await getSchedule(2026, apiCtx);
           const race = schedule.find(r => parseInt(r.round, 10) === rd);
           const raceName = race ? race.raceName : '';
           
           let winnerCode = 'VER';
           try {
-            const results = await getRaceResult(2026, rd, false);
+            const results = await getRaceResult(2026, rd, false, apiCtx);
             if (results.length > 0 && results[0].driver?.code) {
               winnerCode = results[0].driver.code;
             }
@@ -559,9 +564,10 @@ export default {
     }
 
     try {
+      const apiCtx = createF1ApiContext();
       console.log("Fetching 2026 schedule from Jolpi...");
       const year = 2026;
-      const schedule = await getSchedule(year);
+      const schedule = await getSchedule(year, apiCtx);
       console.log(`Loaded schedule with ${schedule.length} rounds.`);
 
       const now = new Date();
@@ -612,7 +618,7 @@ export default {
       // --- Sync Latest F1 News/Events (only on hourly/low-frequency/manual sync) ---
       if (!isHighFrequency) {
         try {
-          await syncLatestNewsEvents(env, getSession);
+          await syncLatestNewsEvents(env, getSession, schedule, apiCtx);
         } catch (e: any) {
           console.error("Failed to sync latest news/events template:", e.message);
         }
@@ -621,7 +627,7 @@ export default {
       // --- Sync Career Results Standings Templates (only on hourly/low-frequency/manual sync) ---
       if (!isHighFrequency) {
         try {
-          await syncCareerStandingsTemplates(env, getSession);
+          await syncCareerStandingsTemplates(env, getSession, apiCtx);
         } catch (e: any) {
           console.error("Failed to sync Career Results standings templates:", e.message);
         }
@@ -663,12 +669,11 @@ export default {
         const qualiStartTime = race.Qualifying ? new Date(`${race.Qualifying.date}T${race.Qualifying.time || "00:00:00Z"}`) : null;
         let qualiEndTime: Date | null = null;
         if (qualiStartTime) {
-          qualiEndTime = new Date(qualiStartTime.getTime() + 60 * 60 * 1000); // 1 hour duration
+          qualiEndTime = new Date(qualiStartTime.getTime() + 60 * 60 * 1000);
         } else {
-          // Fallback: Day 2 (Saturday) of the weekend. Day 2 is 1 day before the race day.
           qualiEndTime = new Date(`${race.date}T00:00:00Z`);
           qualiEndTime.setUTCDate(qualiEndTime.getUTCDate() - 1);
-          qualiEndTime = new Date(qualiEndTime.getTime() + 18 * 60 * 60 * 1000); // Saturday 18:00 UTC
+          qualiEndTime = new Date(qualiEndTime.getTime() + 18 * 60 * 60 * 1000);
         }
         const isQualiConcluded = now >= qualiEndTime;
 
@@ -676,154 +681,193 @@ export default {
         let isSprintConcluded = false;
         if (race.Sprint) {
           const sprintStartTime = new Date(`${race.Sprint.date}T${race.Sprint.time || "00:00:00Z"}`);
-          sprintEndTime = new Date(sprintStartTime.getTime() + 45 * 60 * 1000); // 45 minutes duration
+          sprintEndTime = new Date(sprintStartTime.getTime() + 45 * 60 * 1000);
           isSprintConcluded = now >= sprintEndTime;
         }
 
         const raceStartTime = new Date(`${race.date}T${race.time || "12:00:00Z"}`);
-        const raceEndTime = new Date(raceStartTime.getTime() + 2 * 60 * 60 * 1000); // 2 hours duration
+        const raceEndTime = new Date(raceStartTime.getTime() + 2 * 60 * 60 * 1000);
         const isRaceConcluded = now >= raceEndTime;
+        const gpSessionCompleted = now >= raceEndTime;
 
-        // --- 1. Smart Check for Grand Prix ---
         const gpKey = `2026_round_${round}_gp_updated`;
-        const gpUpdatedInKV = env.F1_WIKI_STATE ? await env.F1_WIKI_STATE.get(gpKey) === 'true' : false;
-        const gpSessionCompleted = now >= raceEndTime; // GP is completed only after GP race ends
+        const sprintKey = `2026_round_${round}_sprint_updated`;
+        const statsKey = `2026_round_${round}_stats_synced`;
 
+        const [gpUpdatedInKV, sprintUpdatedInKV, statsUpdatedInKV] = env.F1_WIKI_STATE
+          ? await Promise.all([
+              env.F1_WIKI_STATE.get(gpKey).then((v: string | null) => v === 'true'),
+              env.F1_WIKI_STATE.get(sprintKey).then((v: string | null) => v === 'true'),
+              env.F1_WIKI_STATE.get(statsKey).then((v: string | null) => v === 'true'),
+            ])
+          : [false, false, false];
+
+        const sprintFullyHandled = !race.Sprint || sprintUpdatedInKV || !isSprintConcluded;
+        if (gpUpdatedInKV && statsUpdatedInKV && sprintFullyHandled) {
+          console.log(`Round ${round} (${raceName}) fully synced in KV. Skipping all Jolpica fetches.`);
+          continue;
+        }
+
+        const needGpCareerTemplate = gpSessionCompleted && !gpUpdatedInKV;
+        const needSprintTemplate = !!race.Sprint && isSprintConcluded && !sprintUpdatedInKV;
+        const needStats = isRaceConcluded && !statsUpdatedInKV;
+        const needGpPage = !gpUpdatedInKV;
+
+        const needQuali = needGpPage && isQualiConcluded;
+        const needGpResults = needGpCareerTemplate || needStats || (needGpPage && isRaceConcluded);
+        const needSprintResults = needSprintTemplate || (needGpPage && isSprintConcluded);
+        const needStandings = needGpPage && isRaceConcluded;
+        const needDrivers = needGpPage && (isQualiConcluded || isSprintConcluded || isRaceConcluded);
+
+        let qualiResults: any[] = [];
+        let gpResults: any[] = [];
+        let sprintResults: any[] = [];
+        let drivers: any[] = [];
+        let currentDrivers: any[] = [];
+        let prevDrivers: any = null;
+        let currentConstructors: any[] = [];
+        let prevConstructors: any = null;
+
+        if (needQuali || needGpResults || needSprintResults || needStandings || needDrivers) {
+          const roundData = await fetchRoundJolpicaData(
+            year,
+            round,
+            {
+              needQuali,
+              needGpResults,
+              needSprintResults,
+              needStandings,
+              needDrivers,
+              hasSprint: !!race.Sprint,
+            },
+            apiCtx
+          );
+          qualiResults = roundData.qualiResults;
+          gpResults = roundData.gpResults;
+          sprintResults = roundData.sprintResults;
+          drivers = roundData.drivers;
+          currentDrivers = roundData.currentDrivers;
+          prevDrivers = roundData.prevDrivers;
+          currentConstructors = roundData.currentConstructors;
+          prevConstructors = roundData.prevConstructors;
+        }
+
+        // --- 1. Smart Check for Grand Prix Career Results template ---
         if (gpUpdatedInKV) {
           console.log(`Round ${round} GP (${raceName}) already updated (KV cache). Skipping.`);
         } else if (!gpSessionCompleted) {
           console.log(`Round ${round} GP (${raceName}) not completed yet (ends: ${raceEndTime.toISOString()}). Skipping.`);
-        } else {
-          console.log(`Round ${round} GP has completed. Polling results from Jolpi...`);
-          let gpResults: any[] = [];
+        } else if (gpResults.length > 0) {
+          console.log(`Round ${round} GP has completed. Updating career results template if needed...`);
+          const gpTitle = `Template:Career Results/${year} ${raceName}`;
+          let gpWikitext = '';
           try {
-            gpResults = await getRaceResult(year, round, false);
+            const pageInfo = await getPageContent(domain, gpTitle, undefined, apiEndpoint, proxySecret, env.F1_WIKI_STATE);
+            if (pageInfo.exists) {
+              gpWikitext = pageInfo.content;
+            }
           } catch (e: any) {
-            console.log(`  No GP results for round ${round} yet: ${e.message}`);
+            console.error(`  Error fetching GP template: ${e.message}`);
           }
 
-          if (gpResults.length > 0) {
-            const gpTitle = `Template:Career Results/${year} ${raceName}`;
-            let gpWikitext = '';
-            try {
-              const pageInfo = await getPageContent(domain, gpTitle, undefined, apiEndpoint, proxySecret, env.F1_WIKI_STATE);
-              if (pageInfo.exists) {
-                gpWikitext = pageInfo.content;
-              }
-            } catch (e: any) {
-              console.error(`  Error fetching GP template: ${e.message}`);
-            }
-
-            if (gpWikitext && isPlaceholder(gpWikitext)) {
-              console.log(`  GP template is a placeholder. Auto-updating results...`);
-              const currentSession = await getSession();
-              const wikitext = generateWikiResultsText(gpResults, false);
-              await editPage(domain, currentSession, gpTitle, wikitext, "Automated results update from Jolpi API", apiEndpoint);
-              console.log(`  Updated GP template for round ${round}.`);
-            } else if (gpWikitext) {
-              console.log(`  GP template already has results on Fandom.`);
-            }
+          if (gpWikitext && isPlaceholder(gpWikitext)) {
+            console.log(`  GP template is a placeholder. Auto-updating results...`);
+            const currentSession = await getSession();
+            const wikitext = generateWikiResultsText(gpResults, false);
+            await editPage(domain, currentSession, gpTitle, wikitext, "Automated results update from Jolpi API", apiEndpoint);
+            console.log(`  Updated GP template for round ${round}.`);
+          } else if (gpWikitext) {
+            console.log(`  GP template already has results on Fandom.`);
           }
+        } else {
+          console.log(`  No GP results for round ${round} yet.`);
         }
 
-        // --- 2. Smart Check for Sprint ---
+        // --- 2. Smart Check for Sprint Career Results template ---
         if (race.Sprint) {
           const sprintName = raceName.replace("Grand Prix", "Sprint");
-          const sprintKey = `2026_round_${round}_sprint_updated`;
-          const sprintUpdatedInKV = env.F1_WIKI_STATE ? await env.F1_WIKI_STATE.get(sprintKey) === 'true' : false;
-          const sprintSessionCompleted = sprintEndTime ? now >= sprintEndTime : false;
 
           if (sprintUpdatedInKV) {
             console.log(`Round ${round} Sprint (${sprintName}) already updated (KV cache). Skipping.`);
-          } else if (!sprintSessionCompleted) {
+          } else if (!isSprintConcluded) {
             console.log(`Round ${round} Sprint (${sprintName}) not completed yet (ends: ${sprintEndTime?.toISOString()}). Skipping.`);
-          } else {
-            console.log(`Round ${round} Sprint has completed. Polling results from Jolpi...`);
-            let sprintResults: any[] = [];
+          } else if (sprintResults.length > 0) {
+            console.log(`Round ${round} Sprint has completed. Updating sprint template if needed...`);
+            const sprintTitle = `Template:Career Results/${year} ${sprintName}`;
+            let sprintWikitext = '';
             try {
-              sprintResults = await getRaceResult(year, round, true);
+              const pageInfo = await getPageContent(domain, sprintTitle, undefined, apiEndpoint, proxySecret, env.F1_WIKI_STATE);
+              if (pageInfo.exists) {
+                sprintWikitext = pageInfo.content;
+              }
             } catch (e: any) {
-              console.log(`  No Sprint results for round ${round} yet: ${e.message}`);
+              console.error(`  Error fetching Sprint template: ${e.message}`);
             }
 
-            if (sprintResults.length > 0) {
-              const sprintTitle = `Template:Career Results/${year} ${sprintName}`;
-              let sprintWikitext = '';
-              try {
-                const pageInfo = await getPageContent(domain, sprintTitle, undefined, apiEndpoint, proxySecret, env.F1_WIKI_STATE);
-                if (pageInfo.exists) {
-                  sprintWikitext = pageInfo.content;
-                }
-              } catch (e: any) {
-                console.error(`  Error fetching Sprint template: ${e.message}`);
-              }
+            if (sprintWikitext && isPlaceholder(sprintWikitext)) {
+              console.log(`  Sprint template is a placeholder. Auto-updating results...`);
+              const currentSession = await getSession();
+              const wikitext = generateWikiResultsText(sprintResults, true);
+              await editPage(domain, currentSession, sprintTitle, wikitext, "Automated Sprint results update from Jolpi API", apiEndpoint);
 
-              if (sprintWikitext && isPlaceholder(sprintWikitext)) {
-                console.log(`  Sprint template is a placeholder. Auto-updating results...`);
-                const currentSession = await getSession();
-                const wikitext = generateWikiResultsText(sprintResults, true);
-                await editPage(domain, currentSession, sprintTitle, wikitext, "Automated Sprint results update from Jolpi API", apiEndpoint);
-                
-                if (env.F1_WIKI_STATE) {
-                  await env.F1_WIKI_STATE.put(sprintKey, 'true');
-                  console.log(`  Marked round ${round} Sprint as updated in KV.`);
-                }
-              } else if (sprintWikitext) {
-                console.log(`  Sprint template already has results on Fandom.`);
-                if (env.F1_WIKI_STATE) {
-                  await env.F1_WIKI_STATE.put(sprintKey, 'true');
-                  console.log(`  Marked round ${round} Sprint as updated in KV (found existing results on Fandom).`);
-                }
+              if (env.F1_WIKI_STATE) {
+                await env.F1_WIKI_STATE.put(sprintKey, 'true');
+                console.log(`  Marked round ${round} Sprint as updated in KV.`);
+              }
+            } else if (sprintWikitext) {
+              console.log(`  Sprint template already has results on Fandom.`);
+              if (env.F1_WIKI_STATE) {
+                await env.F1_WIKI_STATE.put(sprintKey, 'true');
+                console.log(`  Marked round ${round} Sprint as updated in KV (found existing results on Fandom).`);
               }
             }
           }
         }
 
         // --- 3. Smart Check for Stats Templates ---
-        const statsKey = `2026_round_${round}_stats_synced`;
-        const statsUpdatedInKV = env.F1_WIKI_STATE ? await env.F1_WIKI_STATE.get(statsKey) === 'true' : false;
-
         if (statsUpdatedInKV) {
           console.log(`Round ${round} Stats Templates already synced (KV cache). Skipping.`);
         } else if (!isRaceConcluded) {
           console.log(`Round ${round} Stats Templates not completed yet. Skipping.`);
-        } else {
-          let hasGPResults = false;
-          try {
-            const gpResults = await getRaceResult(year, round, false);
-            hasGPResults = gpResults.length > 0;
-          } catch (e) {}
+        } else if (gpResults.length > 0) {
+          console.log(`GP results available. Running stats sync for round ${round}...`);
+          const isFinalRound = round === schedule.length;
+          await syncStatsTemplates(
+            env,
+            getSession,
+            round,
+            !!race.Sprint,
+            isFinalRound,
+            apiCtx,
+            schedule,
+            gpResults
+          );
 
-          if (hasGPResults) {
-            console.log(`GP results available. Running stats sync for round ${round}...`);
-            const isFinalRound = round === schedule.length;
-            await syncStatsTemplates(env, getSession, round, !!race.Sprint, isFinalRound);
-            
-            if (env.F1_WIKI_STATE) {
-              await env.F1_WIKI_STATE.put(statsKey, 'true');
-              console.log(`Marked round ${round} Stats Templates as synced in KV.`);
-            }
+          if (env.F1_WIKI_STATE) {
+            await env.F1_WIKI_STATE.put(statsKey, 'true');
+            console.log(`Marked round ${round} Stats Templates as synced in KV.`);
           }
         }
 
-        // --- 4. Smart Check for GP Page Sections (Starting Grid, Qualifying, Sprint, Race Results, Standings) ---
+        // --- 4. Smart Check for GP Page Sections ---
         if (gpUpdatedInKV) {
           console.log(`Round ${round} GP Page Sections already finalized (GP results updated in KV). Skipping.`);
         } else {
           try {
             const gpPageTitle = `${year} ${raceName}`;
             console.log(`Checking GP page sections for: ${gpPageTitle}...`);
-            
+
             const pageInfo = await getPageContent(domain, gpPageTitle, undefined, apiEndpoint, proxySecret, env.F1_WIKI_STATE);
             let currentContent = '';
             let isNewPage = false;
-            let drivers: any[] = [];
 
             if (pageInfo.exists) {
               currentContent = pageInfo.content;
             } else {
               console.log(`GP page ${gpPageTitle} does not exist on the wiki. Generating a blank GP page...`);
-              drivers = await getDriversForRaceWithFallback(year, round);
+              if (drivers.length === 0) {
+                drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
+              }
               const racingKey = getF1RacingKey(race.raceName);
               const officialName = await fetchOfficialRaceName(year, racingKey).catch(() => null);
               currentContent = generateBlankGPWikitext(race, drivers, officialName);
@@ -832,39 +876,9 @@ export default {
 
             let updatedContent = currentContent;
             let changes: string[] = [];
+            const raceResults = gpResults;
 
-            let qualiResults: any[] = [];
-            let raceResults: any[] = [];
-            let currentDrivers: any[] = [];
-            let prevDrivers: any = null;
-            let currentConstructors: any[] = [];
-            let prevConstructors: any = null;
-            let sprintResults: any[] = [];
-
-            // Only retrieve page content / fetch data and update sections if at least one session has concluded
             if (isQualiConcluded || isSprintConcluded || isRaceConcluded) {
-              // Fetch data concurrently only for completed sessions
-              const fetched = await Promise.all([
-                isQualiConcluded ? getQualifyingResult(year, round).catch(() => []) : Promise.resolve([]),
-                isRaceConcluded ? getRaceResult(year, round, false).catch(() => []) : Promise.resolve([]),
-                isRaceConcluded ? getDriverStandings(year, round).catch(() => []) : Promise.resolve([]),
-                isRaceConcluded && round > 1 ? getDriverStandings(year, round - 1).catch(() => null) : Promise.resolve(null),
-                isRaceConcluded ? getConstructorStandings(year, round).catch(() => []) : Promise.resolve([]),
-                isRaceConcluded && round > 1 ? getConstructorStandings(year, round - 1).catch(() => null) : Promise.resolve(null),
-                isSprintConcluded ? getRaceResult(year, round, true).catch(() => []) : Promise.resolve([]),
-                getDriversForRaceWithFallback(year, round).catch(() => [])
-              ]);
-
-              qualiResults = fetched[0];
-              raceResults = fetched[1];
-              currentDrivers = fetched[2];
-              prevDrivers = fetched[3];
-              currentConstructors = fetched[4];
-              prevConstructors = fetched[5];
-              sprintResults = fetched[6];
-              drivers = fetched[7];
-
-              // Update Qualifying Results and Starting Grid
               if (qualiResults && qualiResults.length > 0) {
                 const qualifyingWikitext = generateQualifyingWikitext(qualiResults);
                 const bestQualiHeader = findBestHeader(updatedContent, ["=== Qualifying Results ===", "==== Qualifying Results ====", "=== Qualifying ===", "==== Qualifying ===", "===Qualifying Results===", "===Qualifying==="], "=== Qualifying Results ===");
@@ -1089,7 +1103,7 @@ export default {
         }
       }
 
-      console.log("Scheduled sync completed successfully!");
+      console.log(`Scheduled sync completed successfully! Jolpica API calls this run: ${apiCtx.apiCallCount}`);
     } catch (e: any) {
       console.error("Scheduled sync failed:", e.message);
     }
@@ -1433,7 +1447,12 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
 
 const ACTIVE_SEASON = 2026;
 
-async function syncLatestNewsEvents(env: any, getSession: () => Promise<any>): Promise<void> {
+async function syncLatestNewsEvents(
+  env: any,
+  getSession: () => Promise<any>,
+  currentSchedule: ScheduleRace[],
+  apiCtx?: F1ApiContext
+): Promise<void> {
   const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
   const apiEndpoint = env.WIKI_API_ENDPOINT;
   const proxySecret = env.PROXY_SECRET;
@@ -1442,22 +1461,19 @@ async function syncLatestNewsEvents(env: any, getSession: () => Promise<any>): P
 
   try {
     const seasonYear = ACTIVE_SEASON;
-    console.log(`Fetching schedules for ${seasonYear - 1}, ${seasonYear}, and ${seasonYear + 1}...`);
+    console.log(`Fetching schedules for ${seasonYear - 1} and ${seasonYear + 1} (reusing ${seasonYear} from earlier fetch)...`);
 
-    let currentSchedule: Awaited<ReturnType<typeof getSchedule>> = [];
-    try {
-      currentSchedule = await getScheduleWithRetry(seasonYear);
-    } catch (error) {
-      console.error(`Failed to load ${seasonYear} schedule after retries. Skipping events sync to avoid stale data.`, error);
+    if (!currentSchedule || currentSchedule.length === 0) {
+      console.error(`No ${seasonYear} schedule available. Skipping events sync to avoid stale data.`);
       return;
     }
 
     const [prevSchedule, nextSchedule] = await Promise.all([
-      getSchedule(seasonYear - 1).catch((error) => {
+      getSchedule(seasonYear - 1, apiCtx).catch((error) => {
         console.warn(`Failed to load ${seasonYear - 1} schedule (non-fatal):`, error);
         return [];
       }),
-      getSchedule(seasonYear + 1).catch((error) => {
+      getSchedule(seasonYear + 1, apiCtx).catch((error) => {
         console.warn(`Failed to load ${seasonYear + 1} schedule (non-fatal):`, error);
         return [];
       })
@@ -1574,7 +1590,11 @@ function getRaceTimes(race: any): { startTime: Date; endTime: Date } {
   return { startTime, endTime };
 }
 
-async function syncCareerStandingsTemplates(env: any, getSession: () => Promise<any>): Promise<void> {
+async function syncCareerStandingsTemplates(
+  env: any,
+  getSession: () => Promise<any>,
+  apiCtx?: F1ApiContext
+): Promise<void> {
   const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
   const apiEndpoint = env.WIKI_API_ENDPOINT;
   const proxySecret = env.PROXY_SECRET;
@@ -1584,10 +1604,10 @@ async function syncCareerStandingsTemplates(env: any, getSession: () => Promise<
   try {
     const year = 2026;
     console.log("Fetching latest standings from Jolpi API...");
-    
+
     const [driverStandings, constructorStandings] = await Promise.all([
-      getDriverStandings(year).catch(() => []),
-      getConstructorStandings(year).catch(() => [])
+      getDriverStandings(year, undefined, apiCtx).catch(() => []),
+      getConstructorStandings(year, undefined, apiCtx).catch(() => [])
     ]);
 
     if (driverStandings.length === 0 && constructorStandings.length === 0) {
@@ -1653,7 +1673,10 @@ async function syncStatsTemplates(
   getSession: () => Promise<any>,
   round: number,
   isSprintWeekend: boolean,
-  isFinalRound: boolean
+  isFinalRound: boolean,
+  apiCtx?: F1ApiContext,
+  schedule?: ScheduleRace[],
+  prefetchedGpResults?: any[]
 ): Promise<void> {
   const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
   const apiEndpoint = env.WIKI_API_ENDPOINT;
@@ -1662,21 +1685,19 @@ async function syncStatsTemplates(
   console.log(`Starting scheduled Stats Templates sync for round ${round}...`);
 
   try {
-    const cumulativeStats = await get2026CumulativeStats(env, round);
-    
-    // Get latest race info for correction text update
-    const schedule = await getSchedule(2026);
-    const race = schedule.find(r => parseInt(r.round, 10) === round);
+    const cumulativeStats = await get2026CumulativeStats(env, round, false, apiCtx, schedule);
+
+    const seasonSchedule = schedule ?? await getSchedule(2026, apiCtx);
+    const race = seasonSchedule.find(r => parseInt(r.round, 10) === round);
     const raceName = race ? race.raceName : '';
-    
-    // Try to get winner of the race and check achievements
-    let winnerCode = 'VER'; // default fallback
+
+    let winnerCode = 'VER';
     let hasDouble = false;
     let hasHatTrick = false;
     let hasGrandChelem = false;
 
     try {
-      const results = await getRaceResult(2026, round, false);
+      const results = prefetchedGpResults ?? await getRaceResult(2026, round, false, apiCtx);
       if (results.length > 0) {
         if (results[0].driver?.code) {
           winnerCode = results[0].driver.code;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,4 +1,12 @@
-import { getRaceResult, getQualifyingResult, getSchedule, RaceResult } from './f1-api';
+import {
+  getRaceResult,
+  getQualifyingResult,
+  getSchedule,
+  getLapChart,
+  RaceResult,
+  F1ApiContext,
+  ScheduleRace,
+} from './f1-api';
 
 export const CIRCUIT_LENGTHS: Record<string, number> = {
   "albert_park": 5.278,
@@ -428,17 +436,18 @@ export function normalizeName(name: string): string {
 export async function calculateRoundStats(
   year: number,
   round: number,
-  trackLengthParam?: number
+  trackLengthParam?: number,
+  ctx?: F1ApiContext
 ): Promise<Record<string, Partial<DriverStats>>> {
   console.log(`Calculating stats for ${year} Round ${round}...`);
 
   let trackLength = trackLengthParam;
-  const raceResultsPromise = getRaceResult(year, round, false).catch(() => []);
-  const qualiResultsPromise = getQualifyingResult(year, round).catch(() => []);
+  const raceResultsPromise = getRaceResult(year, round, false, ctx).catch(() => []);
+  const qualiResultsPromise = getQualifyingResult(year, round, ctx).catch(() => []);
 
-  let schedulePromise: Promise<any[]> = Promise.resolve([]);
+  let schedulePromise: Promise<ScheduleRace[]> = Promise.resolve([]);
   if (trackLength === undefined) {
-    schedulePromise = getSchedule(year).catch(() => []);
+    schedulePromise = getSchedule(year, ctx).catch(() => []);
   }
 
   const [raceResults, qualiResults, schedule] = await Promise.all([
@@ -455,7 +464,7 @@ export async function calculateRoundStats(
 
   let sprintResults: RaceResult[] = [];
   try {
-    sprintResults = await getRaceResult(year, round, true);
+    sprintResults = await getRaceResult(year, round, true, ctx);
   } catch (e) {
     // No sprint
   }
@@ -464,17 +473,11 @@ export async function calculateRoundStats(
   let lapsLedMap: Record<string, number> = {};
   if (raceResults.length > 0) {
     try {
-      const lapsUrl = `https://api.jolpi.ca/ergast/f1/${year}/${round}/laps.json?limit=2000`;
-      const lapsRes = await fetch(lapsUrl);
-      if (lapsRes.ok) {
-        const lapsData = await lapsRes.json() as any;
-        const races = lapsData?.MRData?.RaceTable?.Races || lapsData?.MRData?.LapsTable?.Races || [];
-        const laps = races[0]?.Laps || [];
-        for (const lap of laps) {
-          const leader = lap.Timings[0]?.driverId;
-          if (leader) {
-            lapsLedMap[leader] = (lapsLedMap[leader] || 0) + 1;
-          }
+      const laps = await getLapChart(year, round, ctx);
+      for (const lap of laps) {
+        const leader = lap.Timings[0]?.driverId;
+        if (leader) {
+          lapsLedMap[leader] = (lapsLedMap[leader] || 0) + 1;
         }
       }
     } catch (e) {
@@ -613,7 +616,8 @@ export async function getRoundStatsCached(
   year: number,
   round: number,
   trackLength?: number,
-  forceRefresh = false
+  forceRefresh = false,
+  ctx?: F1ApiContext
 ): Promise<Record<string, Partial<DriverStats>>> {
   const kvKey = `2026_stats_round_${round}`;
 
@@ -639,7 +643,7 @@ export async function getRoundStatsCached(
     }
   }
 
-  const computed = await calculateRoundStats(year, round, trackLength);
+  const computed = await calculateRoundStats(year, round, trackLength, ctx);
   // Only cache if the data has confirmed race results (at least one driver with Entries > 0)
   if (env && env.F1_WIKI_STATE && Object.keys(computed).length > 0 && hasRaceResults(computed)) {
     await env.F1_WIKI_STATE.put(kvKey, JSON.stringify(computed));
@@ -651,7 +655,13 @@ export async function getRoundStatsCached(
 }
 
 // Get cumulative 2026 stats up to a specific round
-export async function get2026CumulativeStats(env: any, upToRound: number, forceRefresh = false): Promise<Record<string, DriverStats>> {
+export async function get2026CumulativeStats(
+  env: any,
+  upToRound: number,
+  forceRefresh = false,
+  ctx?: F1ApiContext,
+  schedule?: ScheduleRace[]
+): Promise<Record<string, DriverStats>> {
   if (upToRound <= 0) return {};
 
   const targetKey = `2026_cumulative_stats_up_to_${upToRound}`;
@@ -708,19 +718,19 @@ export async function get2026CumulativeStats(env: any, upToRound: number, forceR
     }
   };
 
-  // Fetch schedule once if we have rounds to calculate
-  let schedule: any[] = [];
-  if (startRound <= upToRound) {
-    schedule = await getSchedule(2026).catch(() => []);
+  // Fetch schedule once if we have rounds to calculate (reuse caller-provided schedule when available)
+  let seasonSchedule: ScheduleRace[] = schedule ?? [];
+  if (startRound <= upToRound && seasonSchedule.length === 0) {
+    seasonSchedule = await getSchedule(2026, ctx).catch(() => []);
   }
 
   // Calculate remaining rounds
   for (let r = startRound; r <= upToRound; r++) {
-    const raceInfo = schedule.find(x => parseInt(x.round, 10) === r);
+    const raceInfo = seasonSchedule.find(x => parseInt(x.round, 10) === r);
     const circuitId = raceInfo?.Circuit?.circuitId;
     const trackLength = circuitId ? (CIRCUIT_LENGTHS[circuitId] || 0) : 0;
 
-    const roundData = await getRoundStatsCached(env, 2026, r, trackLength, forceRefresh).catch(() => ({}));
+    const roundData = await getRoundStatsCached(env, 2026, r, trackLength, forceRefresh, ctx).catch(() => ({}));
     Object.entries(roundData).forEach(([driverId, stats]) => {
       initDriver(driverId);
       Object.entries(stats).forEach(([statKey, value]) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes hourly/10-minute cron jobs hitting Jolpica's 500 req/hour rate limit (`HTTP 429 Too Many Requests`).

### Changes

- **`src/f1-api-cache.ts`** — New per-run cache with in-flight request deduplication and exponential/`Retry-After` backoff on 429 responses (up to 4 retries).
- **`src/f1-api.ts`** — All Jolpica endpoints now accept an optional `F1ApiContext`. Added `fetchRoundJolpicaData()` to batch-fetch everything a round needs in one parallel pass.
- **`src/stats.ts`** — Stats calculations reuse the same context and schedule; lap chart fetches go through the cache layer.
- **`src/index.ts` scheduled sync**:
  - One `F1ApiContext` per cron invocation; logs total Jolpica calls at completion.
  - Reuses the initial 2026 schedule in `syncLatestNewsEvents` (eliminates duplicate `2026.json` fetch).
  - Reads all KV sync flags (`gp`, `sprint`, `stats`) in parallel and **skips entire rounds** when fully synced.
  - Fetches each round's Jolpica data **once** and reuses it across career templates, stats sync, and GP page updates.
  - Passes pre-fetched GP results into stats sync to avoid another `results.json` call.

### Expected API call reduction

| Scenario | Before | After |
|----------|--------|-------|
| Quiet hour (KV warm) | ~6 | ~4 (no duplicate 2026 schedule) |
| Race weekend / 10-min cron | ~9–12 per run | ~3–5 per run (batch + cache) |
| Post-race (same round, multiple sections) | Up to 4× `results.json` | 1× `results.json` |

### Verification

- `tsc --noEmit` passes
- `npx tsx scripts/verify-jolpica-cache.ts` confirms schedule dedup, in-flight dedup, and 429 backoff behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

