### PR TITLE
Fix infobox cron updates corrupting template values

### DIFF
--- a/scripts/verify-infobox-update.ts
+++ b/scripts/verify-infobox-update.ts
@@ -1,0 +1,58 @@
+/**
+ * Verifies infobox parameter parsing does not break on }} inside template values.
+ * Run: npx tsx scripts/verify-infobox-update.ts
+ */
+import {
+  updateParameterInInfobox,
+  getInfoboxParameterValue,
+  isInfoboxParameterEmpty,
+} from '../src/index';
+
+const sampleInfobox = `{{Infobox_Race
+| pole = George Russell
+| polenation = GBR
+| poleteam = {{GER}} {{Mercedes-CON}}
+| poletime = 1:06.113
+| fastestlap =
+}}`;
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+// 1. Reading existing value with nested templates
+const poleteam = getInfoboxParameterValue(sampleInfobox, 'poleteam');
+assert(poleteam === '{{GER}} {{Mercedes-CON}}', `Expected full poleteam, got: ${poleteam}`);
+assert(!isInfoboxParameterEmpty(poleteam), 'poleteam should not be empty');
+
+// 2. Updating empty field works
+const withWinner = updateParameterInInfobox(sampleInfobox, 'winner', 'Max Verstappen');
+assert(
+  getInfoboxParameterValue(withWinner, 'winner') === 'Max Verstappen',
+  'Should add winner to empty field'
+);
+
+// 3. Updating populated field with same regex path must not corrupt poleteam
+const corruptedAttempt = updateParameterInInfobox(sampleInfobox, 'poleteam', '{{Mercedes-CON}}');
+assert(
+  getInfoboxParameterValue(corruptedAttempt, 'poleteam') === '{{Mercedes-CON}}',
+  `poleteam replace should be clean, got: ${getInfoboxParameterValue(corruptedAttempt, 'poleteam')}`
+);
+assert(
+  !corruptedAttempt.includes('}}}}'),
+  `Should not contain quadruple braces: ${corruptedAttempt}`
+);
+
+// 4. Reproduce exact bug from screenshot: old regex would produce }}}}/duplicate
+const afterBadReplace = updateParameterInInfobox(sampleInfobox, 'poleteam', '{{Mercedes-CON}}');
+assert(
+  afterBadReplace.includes('| poleteam = {{Mercedes-CON}}'),
+  'Single clean replacement expected'
+);
+assert(
+  !afterBadReplace.includes('{{Mercedes-CON}}}}'),
+  'Must not leave orphan braces from partial match'
+);
+
+console.log('PASS: infobox parameter read/update with template values');
+console.log('All infobox verification tests passed.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1143,12 +1143,32 @@ export function findInfoboxRange(wikitext: string): { start: number; end: number
   return { start, end, content: wikitext.slice(start, end) };
 }
 
+function parseInfoboxParamLine(line: string): { name: string; eqIndex: number } | null {
+  const pipeIndex = line.indexOf('|');
+  if (pipeIndex === -1) return null;
+  const eqIndex = line.indexOf('=', pipeIndex);
+  if (eqIndex === -1) return null;
+  const name = line.slice(pipeIndex + 1, eqIndex).trim();
+  return { name, eqIndex };
+}
+
+function findInfoboxParamLineIndex(lines: string[], key: string): number {
+  for (let i = 0; i < lines.length; i++) {
+    const parsed = parseInfoboxParamLine(lines[i]);
+    if (parsed && parsed.name === key) return i;
+  }
+  return -1;
+}
+
 export function getInfoboxParameterValue(infobox: string, key: string): string | null {
-  const escapedKey = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-  const lineRegex = new RegExp(`^\\|[ \\t]*${escapedKey}[ \\t]*=[ \\t]*(.*)$`, 'm');
-  const match = infobox.match(lineRegex);
-  if (!match) return null;
-  return match[1].trim();
+  const lines = infobox.split(/\r?\n/);
+  for (const line of lines) {
+    const parsed = parseInfoboxParamLine(line);
+    if (parsed && parsed.name === key) {
+      return line.slice(parsed.eqIndex + 1).trim();
+    }
+  }
+  return null;
 }
 
 export function isInfoboxParameterEmpty(value: string | null): boolean {
@@ -1157,29 +1177,31 @@ export function isInfoboxParameterEmpty(value: string | null): boolean {
 }
 
 export function updateParameterInInfobox(infobox: string, key: string, value: string): string {
-  const escapedKey = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-  // Match one line per parameter — values may contain }} from wiki templates
-  const lineRegex = new RegExp(`^(\\|[ \\t]*${escapedKey}[ \\t]*=[ \\t]*)(.*)$`, 'm');
+  const lines = infobox.split(/\r?\n/);
+  const lineIndex = findInfoboxParamLineIndex(lines, key);
 
-  if (lineRegex.test(infobox)) {
-    return infobox.replace(lineRegex, `$1${value}`);
-  }
-
-  // Parameter does not exist, append it before the closing }}
-  const isMultiLine = infobox.includes('\n');
-  if (isMultiLine) {
-    const closingMatch = infobox.match(/\r?\n\s*\}\}\s*$/) || infobox.match(/\s*\}\}\s*$/);
-    if (closingMatch) {
-      const closing = closingMatch[0];
-      return infobox.replace(closing, `\n| ${key} = ${value}${closing}`);
-    }
-  } else {
-    const closingMatch = infobox.match(/\s*\}\}\s*$/);
-    if (closingMatch) {
-      const closing = closingMatch[0];
-      return infobox.replace(closing, `|${key}=${value}${closing}`);
+  if (lineIndex >= 0) {
+    const line = lines[lineIndex];
+    const parsed = parseInfoboxParamLine(line);
+    if (parsed) {
+      lines[lineIndex] = line.slice(0, parsed.eqIndex + 1) + ' ' + value;
+      return lines.join('\n');
     }
   }
+
+  // Parameter does not exist — insert before the closing }}
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim() === '}}') {
+      lines.splice(i, 0, `| ${key} = ${value}`);
+      return lines.join('\n');
+    }
+  }
+
+  const closingIndex = infobox.lastIndexOf('}}');
+  if (closingIndex !== -1) {
+    return infobox.slice(0, closingIndex) + `|${key}=${value}` + infobox.slice(closingIndex);
+  }
+
   return infobox;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1012,6 +1012,11 @@ export default {
                   let infobox = range.content;
                   let infoboxChanged = false;
                   for (const [key, val] of Object.entries(infoboxUpdates)) {
+                    const currentValue = getInfoboxParameterValue(infobox, key);
+                    if (!isInfoboxParameterEmpty(currentValue)) {
+                      console.log(`  Infobox |${key}| already set (${currentValue}). Skipping to preserve existing value.`);
+                      continue;
+                    }
                     const updatedInfobox = updateParameterInInfobox(infobox, key, val);
                     if (updatedInfobox !== infobox) {
                       infobox = updatedInfobox;
@@ -1138,27 +1143,41 @@ export function findInfoboxRange(wikitext: string): { start: number; end: number
   return { start, end, content: wikitext.slice(start, end) };
 }
 
+export function getInfoboxParameterValue(infobox: string, key: string): string | null {
+  const escapedKey = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  const lineRegex = new RegExp(`^\\|[ \\t]*${escapedKey}[ \\t]*=[ \\t]*(.*)$`, 'm');
+  const match = infobox.match(lineRegex);
+  if (!match) return null;
+  return match[1].trim();
+}
+
+export function isInfoboxParameterEmpty(value: string | null): boolean {
+  if (value === null) return true;
+  return value.trim().length === 0;
+}
+
 export function updateParameterInInfobox(infobox: string, key: string, value: string): string {
-  // Check if parameter exists in the infobox
-  const regex = new RegExp(`(\\|[ \\t]*${key}[ \\t]*=[ \\t]*)(.*?)(?=\\s*\\|[ \\t]*[a-zA-Z0-9_]+[ \\t]*=|\\s*\\}\\})`, 's');
-  if (regex.test(infobox)) {
-    // Parameter exists, replace its value
-    return infobox.replace(regex, `$1${value}`);
+  const escapedKey = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  // Match one line per parameter — values may contain }} from wiki templates
+  const lineRegex = new RegExp(`^(\\|[ \\t]*${escapedKey}[ \\t]*=[ \\t]*)(.*)$`, 'm');
+
+  if (lineRegex.test(infobox)) {
+    return infobox.replace(lineRegex, `$1${value}`);
+  }
+
+  // Parameter does not exist, append it before the closing }}
+  const isMultiLine = infobox.includes('\n');
+  if (isMultiLine) {
+    const closingMatch = infobox.match(/\r?\n\s*\}\}\s*$/) || infobox.match(/\s*\}\}\s*$/);
+    if (closingMatch) {
+      const closing = closingMatch[0];
+      return infobox.replace(closing, `\n| ${key} = ${value}${closing}`);
+    }
   } else {
-    // Parameter does not exist, append it before the closing }}
-    const isMultiLine = infobox.includes('\n');
-    if (isMultiLine) {
-      const closingMatch = infobox.match(/\r?\n\s*\}\}\s*$/) || infobox.match(/\s*\}\}\s*$/);
-      if (closingMatch) {
-        const closing = closingMatch[0];
-        return infobox.replace(closing, `\n| ${key} = ${value}${closing}`);
-      }
-    } else {
-      const closingMatch = infobox.match(/\s*\}\}\s*$/);
-      if (closingMatch) {
-        const closing = closingMatch[0];
-        return infobox.replace(closing, `|${key}=${value}${closing}`);
-      }
+    const closingMatch = infobox.match(/\s*\}\}\s*$/);
+    if (closingMatch) {
+      const closing = closingMatch[0];
+      return infobox.replace(closing, `|${key}=${value}${closing}`);
     }
   }
   return infobox;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a cron job bug that corrupted infobox fields on GP articles when values already contained wiki templates with `}}`.

### Root cause

`updateParameterInInfobox` used a regex with a `(?=\s*\}\})` lookahead to find the end of a parameter value. For a line like:

```
| poleteam = {{GER}} {{Mercedes-CON}}
```

the lookahead matched the `}}` inside `{{GER}}`, so only `{{GER` was captured and replaced. The leftover `}} {{Mercedes-CON}}` stayed in place, producing corrupted output such as:

```
| poleteam = {{GER}} {{Mercedes-CON}}}} {{Mercedes-CON}}
```

This was observed on the [2026 Austrian Grand Prix](https://f1.fandom.com/wiki/2026_Austrian_Grand_Prix) article when SYnVerse Bot ran an automated infobox update.

### Fix

1. **Line-based parameter matching** — infobox params are one-per-line on Fandom; match from `| key =` to end of line so `}}` inside template values is safe.
2. **Preserve existing values** — skip infobox fields that already have a non-empty value, consistent with how LLM report sections are protected from overwriting human edits.

### Verification

- `tsc --noEmit` passes
- `npx tsx scripts/verify-infobox-update.ts` reproduces and confirms the fix for the `poleteam = {{GER}} {{Mercedes-CON}}` case
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

