### PR TITLE
Fix CodeQL ReDoS alerts with line-based wikitext parsing

### DIFF
--- a/scripts/verify-wikitext-parse.ts
+++ b/scripts/verify-wikitext-parse.ts
@@ -1,0 +1,69 @@
+/**
+ * Verifies line-based wikitext parsing (CodeQL-safe replacements).
+ * Run: npx tsx scripts/verify-wikitext-parse.ts
+ */
+import { findBestHeader } from '../src/index';
+import {
+  getSectionContent,
+  isSectionEmptyOrPlaceholder,
+  replaceSectionWikitext,
+} from '../src/wiki';
+import { parsePipeParamLine } from '../src/wikitext-parse';
+import { normalizeName } from '../src/stats';
+
+function assert(condition: boolean, message: string) {
+  if (!condition) throw new Error(message);
+}
+
+const samplePage = `Intro text
+
+=== Qualifying Results ===
+{{GER}} {{Mercedes-CON}} pole info
+More quali content
+
+== Standings ==
+Points table
+
+=== Qualifying Results ===
+duplicate section
+`;
+
+// 1. replaceSectionWikitext preserves templates with }}
+const replaced = replaceSectionWikitext(
+  samplePage,
+  '=== Qualifying Results ===',
+  '=== Qualifying Results ===\nNew quali table\n'
+);
+assert(replaced.includes('{{GER}} {{Mercedes-CON}}') === false, 'Old content should be replaced');
+assert(replaced.includes('New quali table'), 'New content should be present');
+assert(!replaced.includes('duplicate section'), 'Duplicate section should be removed');
+assert(replaced.includes('== Standings =='), 'Next section should remain');
+
+// 2. getSectionContent reads full section including templates
+const section = getSectionContent(samplePage, '=== Qualifying Results ===');
+assert(section.includes('{{GER}} {{Mercedes-CON}}'), `Section should include templates, got: ${section}`);
+
+// 3. findBestHeader without dynamic regex on full page
+const header = findBestHeader(
+  samplePage,
+  ['==== Starting Grid ====', '=== Qualifying Results ===', '=== Qualifying ==='],
+  '=== Qualifying Results ==='
+);
+assert(header === '=== Qualifying Results ===', `Expected quali header, got ${header}`);
+
+// 4. isSectionEmptyOrPlaceholder strips nested templates safely
+assert(isSectionEmptyOrPlaceholder('{{Weather|{{GER}} temp}}'), 'Template-only section is empty');
+assert(!isSectionEmptyOrPlaceholder('Actual race report text here'), 'Text section is not empty');
+
+// 5. parsePipeParamLine handles template values with }}
+const line = '| Lewis Hamilton                  = {{#expr: 100 + {{Career Results/Points/2026|{{{1}}}}} }}';
+const parsed = parsePipeParamLine(line);
+assert(parsed !== null, 'Should parse stats line');
+assert(
+  parsed!.value.includes('Career Results/Points/2026'),
+  `Value should be complete template expression, got: ${parsed!.value}`
+);
+assert(normalizeName(parsed!.name) === normalizeName('Lewis Hamilton'), 'Name should parse');
+
+console.log('PASS: wikitext line-based parsing verification');
+console.log('All wikitext parse verification tests passed.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { frontendHtml } from './frontend-html';
+import { pageContainsHeader } from './wikitext-parse';
 import { 
   getSchedule,
   getRaceResult, 
@@ -1207,25 +1208,8 @@ export function updateParameterInInfobox(infobox: string, key: string, value: st
 
 export function findBestHeader(fullText: string, options: string[], defaultHeader: string): string {
   for (const opt of options) {
-    const cleanOpt = opt.trim();
-    const match = cleanOpt.match(/^(=+)\s*(.*?)\s*(=+)$/);
-    if (match) {
-      const level = match[1].length;
-      const name = match[2].trim();
-      const escapedName = name
-        .replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-        .replace(/\s+/g, '\\s+');
-      // Construct regex that matches the exact level of heading on its own line
-      const regex = new RegExp(`(^|\\r?\\n)[ \\t]*={${level}}\\s*${escapedName}\\s*={${level}}[ \\t]*(?:\\r?\\n|$)`, 'i');
-      if (regex.test(fullText)) {
-        return opt;
-      }
-    } else {
-      const escaped = cleanOpt.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-      const regex = new RegExp(`(^|\\r?\\n)[ \\t]*${escaped}[ \\t]*(?:\\r?\\n|$)`, 'i');
-      if (regex.test(fullText)) {
-        return opt;
-      }
+    if (pageContainsHeader(fullText, opt.trim())) {
+      return opt;
     }
   }
   return defaultHeader;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -7,6 +7,7 @@ import {
   F1ApiContext,
   ScheduleRace,
 } from './f1-api';
+import { parsePipeParamLine } from './wikitext-parse';
 
 export const CIRCUIT_LENGTHS: Record<string, number> = {
   "albert_park": 5.278,
@@ -816,14 +817,10 @@ export function updateTemplateContent(
     const processedDrivers = new Set<string>();
 
     const newLines = lines.map(line => {
-      const match = line.match(/^(\s*\|\s*)([^=]+?)(\s*=\s*)(.+?)(\s*)$/);
-      if (!match) return line;
+      const parsed = parsePipeParamLine(line);
+      if (!parsed) return line;
 
-      const prefix = match[1];
-      const name = match[2].trim();
-      const separator = match[3];
-      const currentValue = match[4].trim();
-      const suffix = match[5];
+      const { prefix, name, separator, value: currentValue, suffix } = parsed;
 
       const matchedDriverId = Object.keys(driverIdToWikiName).find(
         id => normalizeName(driverIdToWikiName[id]) === normalizeName(name)
@@ -930,10 +927,9 @@ export function updateTemplateContent(
   for (let i = currentDriversLineIdx + 1; i < otherDriversEndLineIdx; i++) {
     if (i === otherDriversLineIdx) continue; // Skip the "<!-- OTHER DRIVERS -->" divider line
     const line = lines[i];
-    const match = line.match(/^(\s*\|\s*)([^=]+?)(\s*=\s*)(.+?)(\s*)$/);
-    if (match) {
-      const name = match[2].trim();
-      const value = match[4].trim();
+    const parsed = parsePipeParamLine(line);
+    if (parsed) {
+      const { name, value } = parsed;
       existingTemplateDrivers.set(normalizeName(name), {
         originalName: name,
         originalValue: value

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -1,3 +1,11 @@
+import {
+  findSectionRanges,
+  splitLines,
+  stripLeadingHeadingFromContent,
+  stripWikiComments,
+  stripWikiTemplates,
+} from './wikitext-parse';
+
 export interface WikiConfig {
   domain: string; // e.g. f1.fandom.com
   username: string;
@@ -353,125 +361,56 @@ export async function editPage(
 }
 
 export function replaceSectionWikitext(fullText: string, header: string, newContent: string): string {
-  // Clean up whitespace
   const cleanHeader = header.trim();
-  const match = cleanHeader.match(/^(=+)\s*(.*?)\s*(=+)$/);
-  
-  let regex: RegExp;
-  let levelNum = 2;
-  let name = cleanHeader;
-  
-  if (match) {
-    levelNum = match[1].length;
-    name = match[2].trim();
-    const escapedName = name
-      .replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-      .replace(/\s+/g, '\\s+');
-    
-    // Matches the heading on its own line: preceding boundary/newline ($1), heading line ($2), and section content ($3)
-    regex = new RegExp(`(^|\\r?\\n)([ \\t]*={${levelNum}}\\s*${escapedName}\\s*={${levelNum}}[ \\t]*(?:\\r?\\n|$))([\\s\\S]*?)(?=\\r?\\n==+|$)`, 'gi');
-  } else {
-    const escapedHeader = cleanHeader.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-    regex = new RegExp(`(^|\\r?\\n)(${escapedHeader}\\s*[\\r\\n]+)([\\s\\S]*?)(?=\\r?\\n==+|$)`, 'gi');
-  }
+  const strippedContent = stripLeadingHeadingFromContent(newContent);
+  const lines = splitLines(fullText);
+  const ranges = findSectionRanges(fullText, cleanHeader);
 
-  // Strip any leading heading from newContent to avoid duplicate headings
-  const strippedContent = newContent.replace(/^\s*={1,6}\s*.*?\s*={1,6}\s*(?:\r?\n|$)/, '').trim();
-
-  // Find all matches for the section
-  const matches: RegExpExecArray[] = [];
-  let m: RegExpExecArray | null;
-  regex.lastIndex = 0;
-  while ((m = regex.exec(fullText)) !== null) {
-    matches.push(m);
-    if (m.index === regex.lastIndex) {
-      regex.lastIndex++;
-    }
-  }
-
-  if (matches.length > 0) {
-    // Reconstruct the text: replace the first occurrence, delete any duplicate occurrences
-    let result = '';
-    let lastIndex = 0;
-    
-    for (let i = 0; i < matches.length; i++) {
-      const matchObj = matches[i];
-      const matchIndex = matchObj.index;
-      const matchLength = matchObj[0].length;
-      
-      // Append text before this match
-      result += fullText.slice(lastIndex, matchIndex);
-      
-      if (i === 0) {
-        // First match: replace its content with the new content
-        const prefix = matchObj[1];
-        const headingLine = matchObj[2];
-        result += `${prefix}${headingLine}${strippedContent}\n\n`;
-      } else {
-        // Subsequent matches: duplicate sections, remove them completely
-        console.log(`Removing duplicate section heading: "${matchObj[2].trim()}"`);
-      }
-      
-      lastIndex = matchIndex + matchLength;
-    }
-    
-    // Append remaining text
-    result += fullText.slice(lastIndex);
-    return result;
-  } else {
-    // Section not found, append to the end of the page
+  if (ranges.length === 0) {
     return `${fullText.trim()}\n\n${cleanHeader}\n${strippedContent}\n`;
   }
+
+  let result: string[] = [];
+  let cursor = 0;
+
+  for (let i = 0; i < ranges.length; i++) {
+    const { startLine, endLine, headingLine } = ranges[i];
+    result.push(...lines.slice(cursor, startLine));
+
+    if (i === 0) {
+      result.push(headingLine, strippedContent, '');
+    } else {
+      console.log(`Removing duplicate section heading: "${headingLine.trim()}"`);
+    }
+
+    cursor = endLine;
+  }
+
+  result.push(...lines.slice(cursor));
+  return result.join('\n');
 }
 
 export function getSectionContent(fullText: string, header: string): string {
-  const cleanHeader = header.trim();
-  const match = cleanHeader.match(/^(=+)\s*(.*?)\s*(=+)$/);
-  
-  let regex: RegExp;
-  let levelNum = 2;
-  let name = cleanHeader;
-  
-  if (match) {
-    levelNum = match[1].length;
-    name = match[2].trim();
-    const escapedName = name
-      .replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
-      .replace(/\s+/g, '\\s+');
-    
-    regex = new RegExp(`(?:^|\\r?\\n)(?:[ \\t]*={${levelNum}}\\s*${escapedName}\\s*={${levelNum}}[ \\t]*(?:\\r?\\n|$))([\\s\\S]*?)(?=\\r?\\n==+|$)`, 'i');
-  } else {
-    const escapedHeader = cleanHeader.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-    regex = new RegExp(`(?:^|\\r?\\n)(${escapedHeader}\\s*[\\r\\n]+)([\\s\\S]*?)(?=\\r?\\n==+|$)`, 'i');
-  }
+  const ranges = findSectionRanges(fullText, header.trim());
+  if (ranges.length === 0) return '';
 
-  const result = regex.exec(fullText);
-  if (result) {
-    return match ? result[1] : result[2];
-  }
-  return "";
+  const lines = splitLines(fullText);
+  const { startLine, endLine } = ranges[0];
+  return lines.slice(startLine + 1, endLine).join('\n');
 }
 
 export function isSectionEmptyOrPlaceholder(sectionContent: string): boolean {
-  // Strip comments
-  let text = sectionContent.replace(/<!--[\s\S]*?-->/g, '');
-  
-  // Strip templates (e.g. {{Weather...}}, {{AvailableTyres...}}, {{Clear}})
-  text = text.replace(/\{\{[\s\S]*?\}\}/g, '');
-  
-  // Strip lists of images/videos/references placeholders
+  let text = stripWikiComments(sectionContent);
+  text = stripWikiTemplates(text);
   text = text.replace(/Images and Videos:\s*/gi, '');
   text = text.replace(/References:\s*/gi, '');
   text = text.replace(/<references\s*\/>/gi, '');
-  
-  // Strip whitespace
   text = text.trim();
-  
-  // Check if remaining text is empty or common placeholders
-  if (text === "" || text.toLowerCase() === "tba" || text.toLowerCase() === "tbd") {
+
+  if (text === '' || text.toLowerCase() === 'tba' || text.toLowerCase() === 'tbd') {
     return true;
   }
-  
+
   return false;
 }
 

--- a/src/wikitext-parse.ts
+++ b/src/wikitext-parse.ts
@@ -6,9 +6,10 @@ export function splitLines(text: string): string[] {
 
 export function parseWikiHeading(line: string): { level: number; name: string } | null {
   const trimmed = line.trim();
-  const equalsPrefix = trimmed.match(/^(=+)/);
-  if (!equalsPrefix) return null;
-  const level = equalsPrefix[1].length;
+  let level = 0;
+  while (level < trimmed.length && trimmed[level] === '=') {
+    level++;
+  }
   if (level < 2) return null;
   const suffix = '='.repeat(level);
   if (!trimmed.endsWith(suffix)) return null;
@@ -22,17 +23,16 @@ export function isWikiHeadingLine(line: string): boolean {
 }
 
 export function sectionHeadingMatches(line: string, header: string): boolean {
-  const cleanHeader = header.trim();
-  const headerParts = cleanHeader.match(/^(=+)\s*(.*?)\s*\1$/);
-  if (headerParts) {
+  const parsedHeader = parseWikiHeading(header.trim());
+  if (parsedHeader) {
     const parsed = parseWikiHeading(line);
     if (!parsed) return false;
     return (
-      parsed.level === headerParts[1].length &&
-      parsed.name.toLowerCase() === headerParts[2].trim().toLowerCase()
+      parsed.level === parsedHeader.level &&
+      parsed.name.toLowerCase() === parsedHeader.name.toLowerCase()
     );
   }
-  return line.trim() === cleanHeader;
+  return line.trim() === header.trim();
 }
 
 export interface SectionRange {
@@ -128,15 +128,18 @@ export function parsePipeParamLine(line: string): {
   value: string;
   suffix: string;
 } | null {
-  const prefixMatch = line.match(/^(\s*\|\s*)/);
-  if (!prefixMatch) return null;
+  let start = 0;
+  while (start < line.length && (line[start] === ' ' || line[start] === '\t')) start++;
+  if (line[start] !== '|') return null;
+  let prefixEnd = start + 1;
+  while (prefixEnd < line.length && (line[prefixEnd] === ' ' || line[prefixEnd] === '\t')) prefixEnd++;
+  const prefix = line.slice(start, prefixEnd);
 
-  const prefix = prefixMatch[1];
-  const eqIndex = line.indexOf('=', prefix.length);
+  const eqIndex = line.indexOf('=', prefixEnd);
   if (eqIndex === -1) return null;
 
-  const name = line.slice(prefix.length, eqIndex).trim();
-  const nameStart = line.indexOf(name, prefix.length);
+  const name = line.slice(prefixEnd, eqIndex).trim();
+  const nameStart = line.indexOf(name, prefixEnd);
   if (nameStart === -1) return null;
 
   const separator = line.slice(nameStart + name.length, eqIndex + 1);

--- a/src/wikitext-parse.ts
+++ b/src/wikitext-parse.ts
@@ -1,0 +1,149 @@
+/** Line-based wikitext parsing helpers (avoids polynomial regex on wiki content). */
+
+export function splitLines(text: string): string[] {
+  return text.split(/\r?\n/);
+}
+
+export function parseWikiHeading(line: string): { level: number; name: string } | null {
+  const trimmed = line.trim();
+  const equalsPrefix = trimmed.match(/^(=+)/);
+  if (!equalsPrefix) return null;
+  const level = equalsPrefix[1].length;
+  if (level < 2) return null;
+  const suffix = '='.repeat(level);
+  if (!trimmed.endsWith(suffix)) return null;
+  const name = trimmed.slice(level, trimmed.length - level).trim();
+  if (!name) return null;
+  return { level, name };
+}
+
+export function isWikiHeadingLine(line: string): boolean {
+  return parseWikiHeading(line) !== null;
+}
+
+export function sectionHeadingMatches(line: string, header: string): boolean {
+  const cleanHeader = header.trim();
+  const headerParts = cleanHeader.match(/^(=+)\s*(.*?)\s*\1$/);
+  if (headerParts) {
+    const parsed = parseWikiHeading(line);
+    if (!parsed) return false;
+    return (
+      parsed.level === headerParts[1].length &&
+      parsed.name.toLowerCase() === headerParts[2].trim().toLowerCase()
+    );
+  }
+  return line.trim() === cleanHeader;
+}
+
+export interface SectionRange {
+  startLine: number;
+  endLine: number;
+  headingLine: string;
+}
+
+export function findSectionRanges(fullText: string, header: string): SectionRange[] {
+  const lines = splitLines(fullText);
+  const ranges: SectionRange[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!sectionHeadingMatches(lines[i], header)) continue;
+
+    let endLine = lines.length;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (isWikiHeadingLine(lines[j])) {
+        endLine = j;
+        break;
+      }
+    }
+
+    ranges.push({ startLine: i, endLine, headingLine: lines[i] });
+  }
+
+  return ranges;
+}
+
+export function pageContainsHeader(fullText: string, header: string): boolean {
+  return splitLines(fullText).some(line => sectionHeadingMatches(line, header));
+}
+
+export function stripLeadingHeadingFromContent(content: string): string {
+  const lines = splitLines(content);
+  if (lines.length > 0 && parseWikiHeading(lines[0])) {
+    return lines.slice(1).join('\n').trim();
+  }
+  return content.trim();
+}
+
+export function stripWikiComments(text: string): string {
+  let result = '';
+  let i = 0;
+  while (i < text.length) {
+    const start = text.indexOf('<!--', i);
+    if (start === -1) {
+      result += text.slice(i);
+      break;
+    }
+    result += text.slice(i, start);
+    const end = text.indexOf('-->', start + 4);
+    if (end === -1) break;
+    i = end + 3;
+  }
+  return result;
+}
+
+export function stripWikiTemplates(text: string): string {
+  let result = '';
+  let i = 0;
+  while (i < text.length) {
+    const start = text.indexOf('{{', i);
+    if (start === -1) {
+      result += text.slice(i);
+      break;
+    }
+    result += text.slice(i, start);
+    let depth = 0;
+    let j = start;
+    while (j < text.length - 1) {
+      if (text[j] === '{' && text[j + 1] === '{') {
+        depth++;
+        j += 2;
+      } else if (text[j] === '}' && text[j + 1] === '}') {
+        depth--;
+        j += 2;
+        if (depth === 0) break;
+      } else {
+        j++;
+      }
+    }
+    i = j < text.length ? j : text.length;
+  }
+  return result;
+}
+
+/** Parse a `| name = value` template/stat line, preserving spacing for rebuild. */
+export function parsePipeParamLine(line: string): {
+  prefix: string;
+  name: string;
+  separator: string;
+  value: string;
+  suffix: string;
+} | null {
+  const prefixMatch = line.match(/^(\s*\|\s*)/);
+  if (!prefixMatch) return null;
+
+  const prefix = prefixMatch[1];
+  const eqIndex = line.indexOf('=', prefix.length);
+  if (eqIndex === -1) return null;
+
+  const name = line.slice(prefix.length, eqIndex).trim();
+  const nameStart = line.indexOf(name, prefix.length);
+  if (nameStart === -1) return null;
+
+  const separator = line.slice(nameStart + name.length, eqIndex + 1);
+  const afterEq = line.slice(eqIndex + 1);
+  const valueEnd = afterEq.trimEnd();
+  const value = valueEnd.trim();
+  const suffix = afterEq.slice(valueEnd.length);
+
+  return { prefix, name, separator, value, suffix };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the remaining **Polynomial regular expression used on uncontrolled data** (ReDoS) patterns on Fandom wikitext by replacing dynamic regex with line-based string parsing.

### Locations fixed (5)

| File | Function | Change |
|------|----------|--------|
| `src/wiki.ts` | `replaceSectionWikitext` | Scan lines for section headings; replace/remove sections without `[\s\S]*?` regex |
| `src/wiki.ts` | `getSectionContent` | Return lines between matched heading and next wiki heading |
| `src/wiki.ts` | `isSectionEmptyOrPlaceholder` | Strip comments/templates via index/brace-depth scanning |
| `src/index.ts` | `findBestHeader` | Check hardcoded header options with `pageContainsHeader()` |
| `src/stats.ts` | `updateTemplateContent` | Parse `\| name = value` lines with `parsePipeParamLine()` |

### New module

`src/wikitext-parse.ts` — shared helpers for heading detection, section ranges, template/comment stripping, and pipe-param lines.

### Why this matters

The previous regex approach could trigger CodeQL high-severity alerts and had correctness risks when wikitext contained `}}` inside template values (same class of bug as the infobox `poleteam` corruption).

### Verification

- `tsc --noEmit` passes
- `npx tsx scripts/verify-wikitext-parse.ts` — section replace/read, header detection, template stripping, stats line parsing
- `npx tsx scripts/verify-infobox-update.ts` — still passes (infobox fix on main unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b338e163-bb4b-4001-9d9e-e3650dba90d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

