### PR TITLE
Expand cron worker for practice sessions and test drivers

### DIFF
--- a/f1.py
+++ b/f1.py
@@ -277,36 +277,39 @@ def scrape_f1_practice_data(year, race, custom_race_id=None, custom_race_name=No
                 
                 print(f"Found race: {race_info['raceName']} at {circuit_id}")
                 
-                # Race ID mapping based on F1.com URL structure
-                race_id_mapping = {
-                    'hungaroring': '1266',  # Hungarian GP
-                    'silverstone': '1267',  # British GP
-                    'monaco': '1268',       # Monaco GP
-                    'spa': '1269',          # Belgian GP
-                    'monza': '1270',        # Italian GP
-                    'red_bull_ring': '1271', # Austrian GP
-                    'catalunya': '1272',    # Spanish GP
-                    'villeneuve': '1273',   # Canadian GP
-                    'miami': '1274',        # Miami GP
-                    'imola': '1275',        # Emilia-Romagna GP
-                    'marina_bay': '1276',   # Singapore GP
-                    'suzuka': '1277',       # Japanese GP
-                    'losail': '1278',       # Qatar GP
-                    'cota': '1279',         # United States GP
-                    'rodriguez': '1280',    # Mexican GP
-                    'interlagos': '1281',   # Brazilian GP
-                    'vegas': '1282',        # Las Vegas GP
-                    'yas_marina': '1283',   # Abu Dhabi GP
-                    'jeddah': '1284',       # Saudi Arabian GP
-                    'albert_park': '1285',  # Australian GP
-                    'shanghai': '1286',     # Chinese GP
-                    'baku': '1287',         # Azerbaijan GP
-                    'zandvoort': '1288',    # Dutch GP
-                }
-                
-                race_id = race_id_mapping.get(circuit_id, '1266')  # Default to Hungarian GP ID
-                
-                print(f"Using race ID: {race_id} for circuit: {circuit_id}")
+                if year == 2026:
+                    race_id = str(1278 + race) if race <= 3 else str(1280 + race)
+                    print(f"Using dynamic 2026 race ID: {race_id} for round {race}")
+                else:
+                    # Race ID mapping based on F1.com URL structure
+                    race_id_mapping = {
+                        'hungaroring': '1266',  # Hungarian GP
+                        'silverstone': '1267',  # British GP
+                        'monaco': '1268',       # Monaco GP
+                        'spa': '1269',          # Belgian GP
+                        'monza': '1270',        # Italian GP
+                        'red_bull_ring': '1271', # Austrian GP
+                        'catalunya': '1272',    # Spanish GP
+                        'villeneuve': '1273',   # Canadian GP
+                        'miami': '1274',        # Miami GP
+                        'imola': '1275',        # Emilia-Romagna GP
+                        'marina_bay': '1276',   # Singapore GP
+                        'suzuka': '1277',       # Japanese GP
+                        'losail': '1278',       # Qatar GP
+                        'cota': '1279',         # United States GP
+                        'rodriguez': '1280',    # Mexican GP
+                        'interlagos': '1281',   # Brazilian GP
+                        'vegas': '1282',        # Las Vegas GP
+                        'yas_marina': '1283',   # Abu Dhabi GP
+                        'jeddah': '1284',       # Saudi Arabian GP
+                        'albert_park': '1285',  # Australian GP
+                        'shanghai': '1286',     # Chinese GP
+                        'baku': '1287',         # Azerbaijan GP
+                        'zandvoort': '1288',    # Dutch GP
+                    }
+                    
+                    race_id = race_id_mapping.get(circuit_id, '1266')  # Default to Hungarian GP ID
+                    print(f"Using race ID: {race_id} for circuit: {circuit_id}")
                 
             else:
                 print(f"Race {race} not found in {year} season")

--- a/scripts/verify-sync-kv.ts
+++ b/scripts/verify-sync-kv.ts
@@ -46,6 +46,9 @@ const timing = {
   isQualiConcluded: true,
   isSprintConcluded: true,
   isRaceConcluded: true,
+  isFp1Concluded: true,
+  isFp2Concluded: true,
+  isFp3Concluded: true,
 };
 
 assert(gpPageSectionRequired('sprint_results', timing), 'Sprint results required on sprint weekend');
@@ -65,6 +68,12 @@ const allSynced = allRequiredGpPageSectionsSynced(
     q3_report: true,
     sprint_report: true,
     race_report: true,
+    practice_results_fp1: true,
+    practice_results_fp2: true,
+    practice_results_fp3: true,
+    fp1_report: true,
+    fp2_report: true,
+    fp3_report: true,
   },
   timing
 );

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -91,6 +91,22 @@ export interface ScheduleRace {
   };
   date: string;
   time?: string;
+  FirstPractice?: {
+    date: string;
+    time?: string;
+  };
+  SecondPractice?: {
+    date: string;
+    time?: string;
+  };
+  ThirdPractice?: {
+    date: string;
+    time?: string;
+  };
+  Qualifying?: {
+    date: string;
+    time?: string;
+  };
   Sprint?: {
     date: string;
     time?: string;
@@ -483,6 +499,30 @@ export function getF1RacingKey(raceName: string): string {
     }
   }
   return nameLower.replace(" grand prix", "").trim().replace(/\s+/g, "-");
+}
+
+/** Slug used in F1.com results URLs (e.g. austrian-grand-prix). */
+export function getF1RaceNameSlug(raceName: string): string {
+  return raceName.toLowerCase().replace(/\s+/g, '-');
+}
+
+/** Dynamic F1.com race ID for 2026 season (2-ID gap after Round 3). */
+export function getF1comRaceId(year: number, round: number): string {
+  if (year === 2026) {
+    return round <= 3 ? String(1278 + round) : String(1280 + round);
+  }
+  return String(1278 + round);
+}
+
+export function buildPracticeSessionUrl(
+  year: number,
+  round: number,
+  raceName: string,
+  session: 1 | 2 | 3
+): string {
+  const raceId = getF1comRaceId(year, round);
+  const raceSlug = getF1RaceNameSlug(raceName);
+  return `https://www.formula1.com/en/results/${year}/races/${raceId}/${raceSlug}/practice/${session}`;
 }
 
 function cleanOfficialName(name: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,12 @@ import {
   mapDriverNames,
   fetchOfficialRaceName,
   getF1RacingKey,
+  buildPracticeSessionUrl,
   createF1ApiContext,
   fetchRoundJolpicaData,
   F1ApiContext,
   ScheduleRace,
+  PracticeSessionData,
 } from './f1-api';
 import { 
   generateGridWikitext, 
@@ -32,7 +34,10 @@ import {
   generateCareerPositionWikitext,
   generateCareerTeamPositionWikitext,
   getNationalityCode,
-  getTeamTemplate
+  getTeamTemplate,
+  addTestDriversToEntryList,
+  detectTestDriversFromFp1,
+  lookupTestDriverNationality,
 } from './wikitext-generator';
 import { 
   loginToWiki, 
@@ -44,7 +49,8 @@ import {
 } from './wiki';
 import { 
   generatePromptContext, 
-  generateReportForSection 
+  generateReportForSection,
+  appendKvWarning,
 } from './llm-reporter';
 import { 
   get2026CumulativeStats, 
@@ -694,6 +700,13 @@ export default {
         }
         const isQualiConcluded = now >= qualiEndTime;
 
+        const fp1EndTime = getPracticeEndTime(race.FirstPractice);
+        const fp2EndTime = getPracticeEndTime(race.SecondPractice);
+        const fp3EndTime = getPracticeEndTime(race.ThirdPractice);
+        const isFp1Concluded = fp1EndTime ? now >= fp1EndTime : false;
+        const isFp2Concluded = fp2EndTime ? now >= fp2EndTime : false;
+        const isFp3Concluded = fp3EndTime ? now >= fp3EndTime : false;
+
         let sprintEndTime: Date | null = null;
         let isSprintConcluded = false;
         if (race.Sprint) {
@@ -715,6 +728,9 @@ export default {
           isQualiConcluded,
           isSprintConcluded,
           isRaceConcluded,
+          isFp1Concluded,
+          isFp2Concluded,
+          isFp3Concluded,
         };
 
         const [
@@ -765,7 +781,14 @@ export default {
         const needGpResults = needGpCareerTemplate || needStats || (needGpPage && isRaceConcluded);
         const needSprintResults = needSprintTemplate || (needGpPage && isSprintConcluded);
         const needStandings = needGpPage && isRaceConcluded;
-        const needDrivers = needGpPage && (isQualiConcluded || isSprintConcluded || isRaceConcluded);
+        const needDrivers = needGpPage && (
+          isQualiConcluded ||
+          isSprintConcluded ||
+          isRaceConcluded ||
+          isFp1Concluded ||
+          isFp2Concluded ||
+          isFp3Concluded
+        );
 
         let qualiResults: any[] = [];
         let gpResults: any[] = [];
@@ -917,6 +940,156 @@ export default {
             let updatedContent = currentContent;
             let changes: string[] = [];
             const raceResults = gpResults;
+            const racingKey = getF1RacingKey(race.raceName);
+
+            const needFp1 = needGpPage && isFp1Concluded;
+            const needFp2 = needGpPage && !race.Sprint && isFp2Concluded;
+            const needFp3 = needGpPage && !race.Sprint && isFp3Concluded;
+            const needPracticeScrape = needFp1 || needFp2 || needFp3;
+
+            let fp1Results: Record<string, PracticeSessionData> | null = null;
+            let fp2Results: Record<string, PracticeSessionData> | null = null;
+            let fp3Results: Record<string, PracticeSessionData> | null = null;
+
+            if (needPracticeScrape) {
+              if (drivers.length === 0) {
+                drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
+              }
+
+              const [fp1, fp2, fp3] = await Promise.all([
+                needFp1
+                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 1), drivers).catch(() => null)
+                  : Promise.resolve(null),
+                needFp2
+                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 2), drivers).catch(() => null)
+                  : Promise.resolve(null),
+                needFp3
+                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 3), drivers).catch(() => null)
+                  : Promise.resolve(null),
+              ]);
+
+              fp1Results = fp1;
+              fp2Results = fp2;
+              fp3Results = fp3;
+
+              const hasAnyPracticeData =
+                (fp1Results && Object.keys(fp1Results).length > 0) ||
+                (fp2Results && Object.keys(fp2Results).length > 0) ||
+                (fp3Results && Object.keys(fp3Results).length > 0);
+
+              if (hasAnyPracticeData) {
+                const practiceWikitext = generatePracticeWikitext(
+                  drivers,
+                  qualiResults.length > 0 ? qualiResults : null,
+                  fp1Results,
+                  fp2Results,
+                  fp3Results,
+                  { hasSprint: !!race.Sprint }
+                );
+
+                const bestPracticeHeader = findBestHeader(
+                  updatedContent,
+                  [
+                    "=== Practice Results ===",
+                    "==== Practice Results ====",
+                    "===Practice Results===",
+                  ],
+                  "=== Practice Results ==="
+                );
+
+                const newPracticeContent = replaceSectionWikitext(updatedContent, bestPracticeHeader, practiceWikitext);
+                if (newPracticeContent !== updatedContent) {
+                  updatedContent = newPracticeContent;
+                  changes.push("Practice Results");
+                }
+
+                if (needFp1 && fp1Results && Object.keys(fp1Results).length > 0 && !isGpPageSectionSynced('practice_results_fp1')) {
+                  await markGpPageSectionSynced('practice_results_fp1');
+                }
+                if (needFp2 && fp2Results && Object.keys(fp2Results).length > 0 && !isGpPageSectionSynced('practice_results_fp2')) {
+                  await markGpPageSectionSynced('practice_results_fp2');
+                }
+                if (needFp3 && fp3Results && Object.keys(fp3Results).length > 0 && !isGpPageSectionSynced('practice_results_fp3')) {
+                  await markGpPageSectionSynced('practice_results_fp3');
+                }
+              }
+
+              if (needFp1 && fp1Results && Object.keys(fp1Results).length > 0) {
+                const testDrivers = detectTestDriversFromFp1(drivers, fp1Results);
+                if (testDrivers.length > 0) {
+                  for (const td of testDrivers) {
+                    if (!lookupTestDriverNationality(td.name)) {
+                      await appendKvWarning(
+                        env.F1_WIKI_STATE,
+                        'missing_test_driver_flags',
+                        `Unknown nationality for test driver ${td.name} (Round ${round} ${raceName})`
+                      );
+                    }
+                  }
+                  const withTestDrivers = addTestDriversToEntryList(updatedContent, testDrivers);
+                  if (withTestDrivers !== updatedContent) {
+                    updatedContent = withTestDrivers;
+                    changes.push("Entry List (Test Drivers)");
+                  }
+                }
+              }
+
+              const fpReportSections: Array<{
+                header: string;
+                title: string;
+                section: GpPageSection;
+                sessionName: string;
+                results: Record<string, PracticeSessionData> | null;
+                required: boolean;
+              }> = [
+                { header: "=== FP1 ===", title: "FP1", section: 'fp1_report', sessionName: 'FP1', results: fp1Results, required: needFp1 },
+                { header: "=== FP2 ===", title: "FP2", section: 'fp2_report', sessionName: 'FP2', results: fp2Results, required: needFp2 },
+                { header: "=== FP3 ===", title: "FP3", section: 'fp3_report', sessionName: 'FP3', results: fp3Results, required: needFp3 },
+              ];
+
+              let practicePromptContext: string | null = null;
+
+              for (const sec of fpReportSections) {
+                if (!sec.required || isGpPageSectionSynced(sec.section)) continue;
+                if (!sec.results || Object.keys(sec.results).length === 0) continue;
+
+                const sectionContent = getSectionContent(updatedContent, sec.header);
+                if (!isSectionEmptyOrPlaceholder(sectionContent)) {
+                  await markGpPageSectionSynced(sec.section);
+                  continue;
+                }
+
+                if (!practicePromptContext) {
+                  practicePromptContext = generatePromptContext(
+                    race,
+                    drivers,
+                    { driverStandings: currentDrivers, constructorStandings: currentConstructors },
+                    qualiResults,
+                    sprintResults,
+                    raceResults,
+                    { fp1: fp1Results, fp2: fp2Results, fp3: fp3Results }
+                  );
+                }
+
+                try {
+                  const reportText = await generateReportForSection(env, sec.title, practicePromptContext, {
+                    year,
+                    racingKey,
+                    sessionName: sec.sessionName,
+                  });
+                  if (reportText && reportText.length > 10) {
+                    const replaced = replaceSectionWikitext(updatedContent, sec.header, reportText);
+                    if (replaced !== updatedContent) {
+                      updatedContent = replaced;
+                      changes.push(`${sec.title} Report`);
+                    }
+                    await markGpPageSectionSynced(sec.section);
+                  }
+                } catch (err: any) {
+                  console.error(`Failed to generate report for ${sec.title}:`, err.message);
+                }
+              }
+            }
 
             if (isQualiConcluded || isSprintConcluded || isRaceConcluded) {
               if (isQualiConcluded && qualiResults && qualiResults.length > 0) {
@@ -1170,6 +1343,12 @@ export default {
 };
 
 // --- HELPER FUNCTIONS FOR SCHEDULED SYNC ---
+
+function getPracticeEndTime(practice?: { date: string; time?: string }): Date | null {
+  if (!practice?.date) return null;
+  const start = new Date(`${practice.date}T${practice.time || "00:00:00Z"}`);
+  return new Date(start.getTime() + 60 * 60 * 1000);
+}
 
 export function findInfoboxRange(wikitext: string): { start: number; end: number; content: string } | null {
   const match = wikitext.match(/\{\{\s*Infobox[ _][a-zA-Z_]+/);
@@ -1436,6 +1615,30 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
         `;
       }
 
+      const rawFlagWarnings = await kv.get('missing_test_driver_flags');
+      const flagWarnings: string[] = rawFlagWarnings ? JSON.parse(rawFlagWarnings) : [];
+      let flagWarningSection = '';
+      if (flagWarnings.length > 0) {
+        flagWarningSection = `
+          <h3 style="margin: 24px 0 12px 0; color: #d97706; font-size: 16px; font-weight: 600;">Warnings (Unknown Test Driver Flags)</h3>
+          <ul style="margin: 0; padding-left: 20px; color: #92400e; font-size: 13px;">
+            ${flagWarnings.map(w => `<li style="margin-bottom: 6px;">${w}</li>`).join('')}
+          </ul>
+        `;
+      }
+
+      const rawCrawlerWarnings = await kv.get('f1_crawler_failures');
+      const crawlerWarnings: string[] = rawCrawlerWarnings ? JSON.parse(rawCrawlerWarnings) : [];
+      let crawlerWarningSection = '';
+      if (crawlerWarnings.length > 0) {
+        crawlerWarningSection = `
+          <h3 style="margin: 24px 0 12px 0; color: #d97706; font-size: 16px; font-weight: 600;">Warnings (F1.com Crawler Failures)</h3>
+          <ul style="margin: 0; padding-left: 20px; color: #92400e; font-size: 13px;">
+            ${crawlerWarnings.map(w => `<li style="margin-bottom: 6px;">${w}</li>`).join('')}
+          </ul>
+        `;
+      }
+
       const emailHtml = `
         <!DOCTYPE html>
         <html>
@@ -1481,6 +1684,8 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
 
                 <!-- Details Section -->
                 ${failedSection}
+                ${flagWarningSection}
+                ${crawlerWarningSection}
               </td>
             </tr>
             <!-- Footer -->
@@ -1511,11 +1716,11 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
 
       if (mailRes.ok) {
         console.log("Daily summary email sent successfully!");
-        // Update KV state to mark today as completed
         await kv.put(lastSentKey, pacificDateStr);
-        // Clear logs for the next day
         await kv.delete(logsKey);
-        console.log("Cleared API call logs in KV.");
+        await kv.delete('missing_test_driver_flags');
+        await kv.delete('f1_crawler_failures');
+        console.log("Cleared API call logs and warning keys in KV.");
       } else {
         console.error(`Failed to send daily summary email: ${mailRes.status} ${await mailRes.text()}`);
       }

--- a/src/llm-reporter.ts
+++ b/src/llm-reporter.ts
@@ -183,12 +183,22 @@ function scoreArticleRelevance(slug: string, sessionName: string): number {
   return score;
 }
 
+function stripHtmlTags(input: string): string {
+  let prev: string;
+  let result = input;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== prev);
+  return result.replace(/</g, '').replace(/>/g, '');
+}
+
 function extractArticleText(html: string): string {
   const paragraphs: string[] = [];
   const pRegex = /<p[^>]*class="[^"]*f1-paragraph[^"]*"[^>]*>([\s\S]*?)<\/p>/gi;
   let match;
   while ((match = pRegex.exec(html)) !== null) {
-    const text = match[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    const text = stripHtmlTags(match[1]).replace(/\s+/g, ' ').trim();
     if (text.length > 20) paragraphs.push(text);
   }
 
@@ -199,7 +209,7 @@ function extractArticleText(html: string): string {
       const genericPRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
       let pMatch;
       while ((pMatch = genericPRegex.exec(articleMatch[1])) !== null) {
-        const text = pMatch[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        const text = stripHtmlTags(pMatch[1]).replace(/\s+/g, ' ').trim();
         if (text.length > 20) paragraphs.push(text);
       }
     }

--- a/src/llm-reporter.ts
+++ b/src/llm-reporter.ts
@@ -1,3 +1,38 @@
+import { PracticeSessionData } from './f1-api';
+
+const SESSION_ARTICLE_KEYWORDS: Record<string, string[]> = {
+  'FP1': ['fp1', 'free-practice-1', 'first-practice', 'practice-1', 'practice-one', 'free-practice-one'],
+  'FP2': ['fp2', 'free-practice-2', 'second-practice', 'practice-2', 'practice-two', 'free-practice-two'],
+  'FP3': ['fp3', 'free-practice-3', 'third-practice', 'practice-3', 'practice-three', 'free-practice-three'],
+};
+
+export async function appendKvWarning(kv: any, key: string, message: string): Promise<void> {
+  if (!kv) return;
+  const raw = await kv.get(key);
+  const warnings: string[] = raw ? JSON.parse(raw) : [];
+  warnings.push(message);
+  await kv.put(key, JSON.stringify(warnings));
+}
+
+export async function logCrawlerFailure(kv: any, message: string): Promise<void> {
+  await appendKvWarning(kv, 'f1_crawler_failures', message);
+}
+
+function formatPracticeSessionContext(
+  label: string,
+  results: Record<string, PracticeSessionData> | null
+): string {
+  if (!results || Object.keys(results).length === 0) return '';
+  let section = `### ${label} Results:\n`;
+  const sorted = Object.values(results).sort(
+    (a, b) => parseInt(a.position, 10) - parseInt(b.position, 10)
+  );
+  for (const r of sorted) {
+    section += `Pos ${r.position}: No. ${r.number} ${r.driverName} (${r.teamName}) - Time: ${r.time}\n`;
+  }
+  return section + '\n';
+}
+
 export function generatePromptContext(
   race: any,
   drivers: any[],
@@ -7,12 +42,16 @@ export function generatePromptContext(
   },
   qualiResults: any[],
   sprintResults: any[],
-  raceResults: any[]
+  raceResults: any[],
+  practiceResults?: {
+    fp1?: Record<string, PracticeSessionData> | null;
+    fp2?: Record<string, PracticeSessionData> | null;
+    fp3?: Record<string, PracticeSessionData> | null;
+  }
 ): string {
   let context = `Race: ${race.season} Round ${race.round} - ${race.raceName}\n`;
   context += `Circuit: ${race.Circuit.circuitName} in ${race.Circuit.Location.locality}, ${race.Circuit.Location.country}\n\n`;
 
-  // 1. Entry List
   if (drivers && drivers.length > 0) {
     context += `### Entry List (Drivers and Teams):\n`;
     drivers.forEach(d => {
@@ -21,7 +60,12 @@ export function generatePromptContext(
     context += `\n`;
   }
 
-  // 2. Standings
+  if (practiceResults) {
+    context += formatPracticeSessionContext('FP1', practiceResults.fp1 ?? null);
+    context += formatPracticeSessionContext('FP2', practiceResults.fp2 ?? null);
+    context += formatPracticeSessionContext('FP3', practiceResults.fp3 ?? null);
+  }
+
   if (standings.driverStandings && standings.driverStandings.length > 0) {
     context += `### Driver Championship Standings (Pre-Race):\n`;
     standings.driverStandings.slice(0, 10).forEach((s, idx) => {
@@ -30,7 +74,6 @@ export function generatePromptContext(
     context += `\n`;
   }
 
-  // 3. Qualifying Results
   if (qualiResults && qualiResults.length > 0) {
     context += `### Qualifying Results:\n`;
     qualiResults.forEach((q, idx) => {
@@ -40,7 +83,6 @@ export function generatePromptContext(
     context += `\n`;
   }
 
-  // 4. Sprint Results
   if (sprintResults && sprintResults.length > 0) {
     context += `### Sprint Race Results:\n`;
     sprintResults.forEach((r, idx) => {
@@ -49,14 +91,12 @@ export function generatePromptContext(
     context += `\n`;
   }
 
-  // 5. Race Results
   if (raceResults && raceResults.length > 0) {
     context += `### Main Race Results:\n`;
     raceResults.forEach((r, idx) => {
       const timeStr = r.Time ? r.Time.time : r.status;
       context += `Pos ${idx + 1}: No. ${r.number} ${r.driver.givenName} ${r.driver.familyName} (${r.constructor.name}) - Time/Status: ${timeStr}, Points: ${r.points}\n`;
     });
-    // Add fastest lap if available
     const fl = raceResults.find(r => r.FastestLap && r.FastestLap.rank === '1');
     if (fl && fl.FastestLap) {
       context += `Fastest Lap: No. ${fl.number} ${fl.driver.givenName} ${fl.driver.familyName} - Time: ${fl.FastestLap.Time.time} on lap ${fl.FastestLap.lap}\n`;
@@ -81,13 +121,20 @@ Follow these rules strictly:
 
   let sectionInstructions = "";
   const nameLower = sectionName.toLowerCase();
-  
+
   if (nameLower === "background") {
     sectionInstructions = `
 The "Background" section should describe:
 - The context of the race in the season (e.g. which round of the championship it is, who is leading the championship).
 - Any driver lineup changes or entry list updates based on the entries.
 - Focus on the pre-race championship narrative and context.`;
+  } else if (nameLower === "fp1" || nameLower === "fp2" || nameLower === "fp3") {
+    sectionInstructions = `
+The "${sectionName}" section should summarize this free practice session:
+- Mention the fastest times and top performers.
+- Highlight any incidents, spins, mechanical issues, or driver feedback reported in the official session context.
+- Note any notable team or tyre performance trends visible from the results.
+- Describe any test driver appearances if relevant.`;
   } else if (nameLower === "q1" || nameLower === "q2" || nameLower === "q3" || nameLower.includes("qualifying")) {
     sectionInstructions = `
 The "${sectionName}" section should summarize the events and eliminations in this segment of qualifying:
@@ -110,6 +157,102 @@ The "Race Report" section should summarize the main Grand Prix race:
   }
 
   return `${baseInstructions}\n${sectionInstructions}\n\n### Race Weekend Data Context:\n${context}`;
+}
+
+function extractArticleLinks(html: string): string[] {
+  const links: string[] = [];
+  const linkRegex = /href="(\/en\/latest\/article\/[^"]+)"/gi;
+  let match;
+  while ((match = linkRegex.exec(html)) !== null) {
+    const path = match[1];
+    if (!links.includes(path)) {
+      links.push(path);
+    }
+  }
+  return links;
+}
+
+function scoreArticleRelevance(slug: string, sessionName: string): number {
+  const keywords = SESSION_ARTICLE_KEYWORDS[sessionName] || [];
+  const slugLower = slug.toLowerCase();
+  let score = 0;
+  for (const kw of keywords) {
+    if (slugLower.includes(kw)) score += 2;
+  }
+  if (slugLower.includes('lap-by-lap') || slugLower.includes('report')) score += 1;
+  return score;
+}
+
+function extractArticleText(html: string): string {
+  const paragraphs: string[] = [];
+  const pRegex = /<p[^>]*class="[^"]*f1-paragraph[^"]*"[^>]*>([\s\S]*?)<\/p>/gi;
+  let match;
+  while ((match = pRegex.exec(html)) !== null) {
+    const text = match[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+    if (text.length > 20) paragraphs.push(text);
+  }
+
+  if (paragraphs.length === 0) {
+    const genericRegex = /<article[^>]*>([\s\S]*?)<\/article>/i;
+    const articleMatch = html.match(genericRegex);
+    if (articleMatch) {
+      const genericPRegex = /<p[^>]*>([\s\S]*?)<\/p>/gi;
+      let pMatch;
+      while ((pMatch = genericPRegex.exec(articleMatch[1])) !== null) {
+        const text = pMatch[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        if (text.length > 20) paragraphs.push(text);
+      }
+    }
+  }
+
+  return paragraphs.join('\n\n');
+}
+
+export async function fetchF1comSessionArticle(
+  year: number,
+  racingKey: string,
+  sessionName: string
+): Promise<string> {
+  const racePageUrl = `https://www.formula1.com/en/racing/${year}/${racingKey}`;
+  const headers = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  };
+
+  const raceRes = await fetch(racePageUrl, { headers });
+  if (!raceRes.ok) {
+    throw new Error(`Failed to fetch F1.com race page (${racePageUrl}): HTTP ${raceRes.status}`);
+  }
+
+  const raceHtml = await raceRes.text();
+  const articleLinks = extractArticleLinks(raceHtml);
+
+  if (articleLinks.length === 0) {
+    throw new Error(`No article links found on F1.com race page for ${racingKey}`);
+  }
+
+  const ranked = articleLinks
+    .map(link => ({ link, score: scoreArticleRelevance(link, sessionName) }))
+    .filter(item => item.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  if (ranked.length === 0) {
+    throw new Error(`No relevant ${sessionName} article found on F1.com race page for ${racingKey}`);
+  }
+
+  const articleUrl = `https://www.formula1.com${ranked[0].link}`;
+  const articleRes = await fetch(articleUrl, { headers });
+  if (!articleRes.ok) {
+    throw new Error(`Failed to fetch F1.com article (${articleUrl}): HTTP ${articleRes.status}`);
+  }
+
+  const articleHtml = await articleRes.text();
+  const text = extractArticleText(articleHtml);
+  if (!text) {
+    throw new Error(`No article text extracted from ${articleUrl}`);
+  }
+
+  return text;
 }
 
 async function callGemini(apiKey: string, prompt: string): Promise<string> {
@@ -175,14 +318,38 @@ async function callWorkersAI(aiBinding: any, prompt: string): Promise<string> {
   return text.trim();
 }
 
-export async function generateReportForSection(env: any, sectionName: string, promptContext: string): Promise<string> {
-  const prompt = getPromptForSection(sectionName, promptContext);
-  
-  // Determine preferred provider priority
+export async function generateReportForSection(
+  env: any,
+  sectionName: string,
+  promptContext: string,
+  options?: {
+    year?: number;
+    racingKey?: string;
+    sessionName?: string;
+  }
+): Promise<string> {
+  let enrichedContext = promptContext;
+
+  if (options?.year && options?.racingKey && options?.sessionName) {
+    try {
+      const articleText = await fetchF1comSessionArticle(
+        options.year,
+        options.racingKey,
+        options.sessionName
+      );
+      enrichedContext += `\n### Official F1.com ${options.sessionName} Article:\n${articleText}\n`;
+    } catch (e: any) {
+      const warning = `Failed to crawl F1.com ${options.sessionName} article for ${options.racingKey} (${options.year}): ${e.message}`;
+      console.warn(warning);
+      await logCrawlerFailure(env.F1_WIKI_STATE, warning);
+    }
+  }
+
+  const prompt = getPromptForSection(sectionName, enrichedContext);
+
   const provider = env.LLM_PROVIDER || (env.GEMINI_API_KEY ? "gemini" : env.OPENAI_API_KEY ? "openai" : "workers-ai");
   const providersToTry = [provider];
-  
-  // Fill fallback chain
+
   const allProviders = ["gemini", "openai", "workers-ai"];
   allProviders.forEach(p => {
     if (!providersToTry.includes(p)) {

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -15,7 +15,13 @@ export type GpPageSection =
   | 'q2_report'
   | 'q3_report'
   | 'sprint_report'
-  | 'race_report';
+  | 'race_report'
+  | 'practice_results_fp1'
+  | 'practice_results_fp2'
+  | 'practice_results_fp3'
+  | 'fp1_report'
+  | 'fp2_report'
+  | 'fp3_report';
 
 export type CareerStandingsPage = 'points' | 'position' | 'team_position';
 
@@ -78,6 +84,12 @@ export const GP_PAGE_SECTIONS: GpPageSection[] = [
   'q3_report',
   'sprint_report',
   'race_report',
+  'practice_results_fp1',
+  'practice_results_fp2',
+  'practice_results_fp3',
+  'fp1_report',
+  'fp2_report',
+  'fp3_report',
 ];
 
 export async function isKvSynced(kv: any, key: string, legacyKeys: string[] = []): Promise<boolean> {
@@ -115,9 +127,20 @@ export function gpPageSectionRequired(
     isQualiConcluded: boolean;
     isSprintConcluded: boolean;
     isRaceConcluded: boolean;
+    isFp1Concluded: boolean;
+    isFp2Concluded: boolean;
+    isFp3Concluded: boolean;
   }
 ): boolean {
-  const { hasSprint, isQualiConcluded, isSprintConcluded, isRaceConcluded } = options;
+  const {
+    hasSprint,
+    isQualiConcluded,
+    isSprintConcluded,
+    isRaceConcluded,
+    isFp1Concluded,
+    isFp2Concluded,
+    isFp3Concluded,
+  } = options;
   switch (section) {
     case 'qualifying':
     case 'grid':
@@ -134,6 +157,15 @@ export function gpPageSectionRequired(
     case 'background_report':
     case 'race_report':
       return isRaceConcluded;
+    case 'practice_results_fp1':
+    case 'fp1_report':
+      return isFp1Concluded;
+    case 'practice_results_fp2':
+    case 'fp2_report':
+      return !hasSprint && isFp2Concluded;
+    case 'practice_results_fp3':
+    case 'fp3_report':
+      return !hasSprint && isFp3Concluded;
     default:
       return false;
   }
@@ -146,6 +178,9 @@ export function allRequiredGpPageSectionsSynced(
     isQualiConcluded: boolean;
     isSprintConcluded: boolean;
     isRaceConcluded: boolean;
+    isFp1Concluded: boolean;
+    isFp2Concluded: boolean;
+    isFp3Concluded: boolean;
   }
 ): boolean {
   return GP_PAGE_SECTIONS.every(

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -559,16 +559,60 @@ export function generatePracticeWikitext(
   qualiResults: QualifyingResult[] | null,
   fp1: Record<string, PracticeSessionData> | null,
   fp2: Record<string, PracticeSessionData> | null,
-  fp3: Record<string, PracticeSessionData> | null
+  fp3: Record<string, PracticeSessionData> | null,
+  options?: { hasSprint?: boolean }
 ): string {
-  // Sort drivers by permanent number
-  const sortedDrivers = [...drivers].sort((a, b) => {
-    const numA = parseInt(a.permanentNumber || '0', 10);
-    const numB = parseInt(b.permanentNumber || '0', 10);
+  const hasSprint = options?.hasSprint ?? false;
+
+  const mainDriverKeys = new Set<string>();
+  for (const driver of drivers) {
+    mainDriverKeys.add(driver.driverId.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
+  }
+
+  const isMainDriver = (name: string): boolean => {
+    const lower = name.toLowerCase();
+    const clean = lower.replace(/[\s'-]/g, '');
+    return mainDriverKeys.has(lower) || mainDriverKeys.has(clean);
+  };
+
+  const collectTestDrivers = (
+    sessionData: Record<string, PracticeSessionData> | null
+  ): PracticeSessionData[] => {
+    if (!sessionData) return [];
+    const seen = new Set<string>();
+    const testDrivers: PracticeSessionData[] = [];
+    for (const data of Object.values(sessionData)) {
+      if (isMainDriver(data.driverName)) continue;
+      const key = data.driverName.toLowerCase().replace(/[\s'-]/g, '');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      testDrivers.push(data);
+    }
+    return testDrivers.sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
+  };
+
+  const testDriverRows = [
+    ...collectTestDrivers(fp1),
+    ...collectTestDrivers(hasSprint ? null : fp2),
+    ...collectTestDrivers(hasSprint ? null : fp3),
+  ].filter((td, idx, arr) => {
+    const key = td.driverName.toLowerCase().replace(/[\s'-]/g, '');
+    return arr.findIndex(x => x.driverName.toLowerCase().replace(/[\s'-]/g, '') === key) === idx;
+  });
+
+  const tableDrivers: Array<Driver | PracticeSessionData> = [...drivers];
+  for (const td of testDriverRows) {
+    tableDrivers.push(td);
+  }
+
+  const sortedDrivers = [...tableDrivers].sort((a, b) => {
+    const numA = parseInt(('permanentNumber' in a ? a.permanentNumber : a.number) || '0', 10);
+    const numB = parseInt(('permanentNumber' in b ? b.permanentNumber : b.number) || '0', 10);
     return numA - numB;
   });
 
-  // Helper to map driver ID to constructor template
   const driverToConstructorTemplate: Record<string, string> = {};
   if (qualiResults) {
     qualiResults.forEach(q => {
@@ -576,12 +620,10 @@ export function generatePracticeWikitext(
     });
   }
 
-  // Find fastest absolute times for each session to convert differentials
   const findFastestTime = (sessionData: Record<string, PracticeSessionData> | null): string | null => {
     if (!sessionData) return null;
     let fastestTime: string | null = null;
 
-    // Look for P1 position first
     for (const data of Object.values(sessionData)) {
       if (data.position === '1') {
         fastestTime = data.time;
@@ -589,7 +631,6 @@ export function generatePracticeWikitext(
       }
     }
 
-    // Fallback search
     if (!fastestTime) {
       for (const data of Object.values(sessionData)) {
         const t = data.time;
@@ -608,43 +649,63 @@ export function generatePracticeWikitext(
   const fp2Fastest = findFastestTime(fp2);
   const fp3Fastest = findFastestTime(fp3);
 
+  const colspan = hasSprint ? 8 : 14;
+
   let output = `===Practice Results===
 The full practice results for the '''{{PAGENAME}}''' are outlined below:
 
 {| class="hidden wikitable sortable" style="width:100%"
-! rowspan="2" |<span style="cursor:help;" title="Car number">No.</span>!! rowspan="2" class="unsortable" |Driver!! rowspan="2" class="unsortable" |Team!! colspan="2" class="unsortable" |FP1 !! colspan="2" class="unsortable" |FP2 !! colspan="2" class="unsortable" |FP3
-|-
-!Time!!Pos!!Time!!Pos!!Time!!Pos`;
+! rowspan="2" |<span style="cursor:help;" title="Car number">No.</span>!! rowspan="2" class="unsortable" |Driver!! rowspan="2" class="unsortable" |Team!! colspan="2" class="unsortable" |FP1`;
 
-  for (const driver of sortedDrivers) {
-    const num = driver.permanentNumber || '0';
-    const name = `${driver.givenName} ${driver.familyName}`;
-    const flag = getFlag(driver.nationality);
-    const team = driverToConstructorTemplate[driver.driverId] || '{{Team-Placeholder}}';
+  if (!hasSprint) {
+    output += ' !! colspan="2" class="unsortable" |FP2 !! colspan="2" class="unsortable" |FP3';
+  }
+
+  output += `
+|-
+!Time!!Pos`;
+
+  if (!hasSprint) {
+    output += '!!Time!!Pos!!Time!!Pos';
+  }
+
+  for (const entry of sortedDrivers) {
+    const isTestDriver = 'driverName' in entry;
+    const num = isTestDriver ? entry.number : (entry.permanentNumber || '0');
+    const name = isTestDriver ? entry.driverName : `${entry.givenName} ${entry.familyName}`;
+    const flag = isTestDriver
+      ? (lookupTestDriverNationality(name) ? getFlag(lookupTestDriverNationality(name)!) : '{{FIA}}')
+      : getFlag(entry.nationality);
+
+    let team: string;
+    if (isTestDriver) {
+      const constructorId = teamNameToConstructorId(entry.teamName);
+      team = constructorId
+        ? (getTeamEntryDetails(constructorId)?.constructor || getTeamTemplate(constructorId, entry.teamName))
+        : `{{${entry.teamName}-CON}}`;
+    } else {
+      team = driverToConstructorTemplate[entry.driverId] || '{{Team-Placeholder}}';
+    }
 
     output += '\n|-';
     output += `\n! ${num}`;
     output += `\n| ${flag} [[${name}]]`;
     output += `\n| ${team}`;
 
-    // Render session cells helper
     const renderSessionCells = (
       sessionData: Record<string, PracticeSessionData> | null,
-      fastestTime: string | null
+      fastestTime: string | null,
+      driverName: string
     ): string => {
       if (!sessionData) {
         return '\n| colspan="2" align=center | {{abbr|DNP|Did Not Participate}}';
       }
 
-      // Try different matching styles (name, driver ID, lowercase, stripped)
       let matchedData: PracticeSessionData | null = null;
-      
       const checkKeys = [
-        name,
-        `${driver.givenName}${driver.familyName}`,
-        driver.driverId,
-        `${driver.givenName} ${driver.familyName}`
-      ].map(k => k.toLowerCase().replace(/[\s'-]/g, ''));
+        driverName,
+        driverName.replace(/[\s'-]/g, ''),
+      ].map(k => k.toLowerCase());
 
       for (const [k, d] of Object.entries(sessionData)) {
         const cleanK = k.toLowerCase().replace(/[\s'-]/g, '');
@@ -670,14 +731,22 @@ The full practice results for the '''{{PAGENAME}}''' are outlined below:
       return '\n| colspan="2" align=center | {{abbr|DNP|Did Not Participate}}';
     };
 
-    output += renderSessionCells(fp1, fp1Fastest);
-    output += renderSessionCells(fp2, fp2Fastest);
-    output += renderSessionCells(fp3, fp3Fastest);
+    output += renderSessionCells(fp1, fp1Fastest, name);
+    if (!hasSprint) {
+      output += renderSessionCells(fp2, fp2Fastest, name);
+      output += renderSessionCells(fp3, fp3Fastest, name);
+    }
   }
 
-  output += `\n|-
-! colspan="14" style="text-align:center" |'''Source:''' <ref name="P1">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_1_classification.pdf {{PAGENAME}} - FP1 Classification] (PDF). Fédération Internationale de l'Automobile.</ref><ref name="P2">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_2_classification.pdf {{PAGENAME}} - FP2 Classification] (PDF). Fédération Internationale de l'Automobile.</ref><ref name="P3">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_3_classification.pdf {{PAGENAME}} - FP3 Classification] (PDF). Fédération Internationale de l'Automobile.</ref>
+  if (hasSprint) {
+    output += `\n|-
+! colspan="${colspan}" style="text-align:center" |'''Source:''' <ref name="P1">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_1_classification.pdf {{PAGENAME}} - FP1 Classification] (PDF). Fédération Internationale de l'Automobile.</ref>
 |}`;
+  } else {
+    output += `\n|-
+! colspan="${colspan}" style="text-align:center" |'''Source:''' <ref name="P1">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_1_classification.pdf {{PAGENAME}} - FP1 Classification] (PDF). Fédération Internationale de l'Automobile.</ref><ref name="P2">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_2_classification.pdf {{PAGENAME}} - FP2 Classification] (PDF). Fédération Internationale de l'Automobile.</ref><ref name="P3">[https://www.fia.com/system/files/decision-document/{{lc: {{PAGENAMEE}}}}_-_free_practice_3_classification.pdf {{PAGENAME}} - FP3 Classification] (PDF). Fédération Internationale de l'Automobile.</ref>
+|}`;
+  }
 
   return output;
 }
@@ -737,7 +806,7 @@ const DRIVER_TO_CONSTRUCTOR_2026: Record<string, string> = {
   "perez": "cadillac"
 };
 
-interface TeamEntryDetails {
+export interface TeamEntryDetails {
   entrant: string;
   constructor: string;
   chassis: string;
@@ -844,6 +913,184 @@ const TEAM_DETAILS_2026: Record<string, TeamEntryDetails> = {
     tyre: "{{Pirelli}}"
   }
 };
+
+export function getTeamEntryDetails(constructorId: string): TeamEntryDetails | null {
+  return TEAM_DETAILS_2026[constructorId] || null;
+}
+
+const TEAM_NAME_TO_CONSTRUCTOR: Record<string, string> = {
+  'mclaren': 'mclaren',
+  'ferrari': 'ferrari',
+  'mercedes': 'mercedes',
+  'red bull': 'red_bull',
+  'red bull racing': 'red_bull',
+  'alpine': 'alpine',
+  'williams': 'williams',
+  'haas': 'haas',
+  'haas f1 team': 'haas',
+  'aston martin': 'aston_martin',
+  'sauber': 'sauber',
+  'audi': 'audi',
+  'racing bulls': 'rb',
+  'visa cash app racing bulls': 'rb',
+  'cadillac': 'cadillac',
+};
+
+export function teamNameToConstructorId(teamName: string): string | null {
+  const key = teamName.toLowerCase().trim();
+  if (TEAM_NAME_TO_CONSTRUCTOR[key]) {
+    return TEAM_NAME_TO_CONSTRUCTOR[key];
+  }
+  for (const [name, id] of Object.entries(TEAM_NAME_TO_CONSTRUCTOR)) {
+    if (key.includes(name) || name.includes(key)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+const TEST_DRIVER_NATIONALITIES: Record<string, string> = {
+  'patricio o\'ward': 'Mexican',
+  'patricio oward': 'Mexican',
+  'felipe drugovich': 'Brazilian',
+  'isack hadjar': 'French',
+  'arvid lindblad': 'British',
+  'gabriel bortoleto': 'Brazilian',
+  'franco colapinto': 'Argentine',
+  'andrea kimi antonelli': 'Italian',
+  'liam lawson': 'New Zealander',
+};
+
+export function lookupTestDriverNationality(driverName: string): string | null {
+  const key = driverName.toLowerCase().replace(/[\s'-]/g, ' ').replace(/\s+/g, ' ').trim();
+  if (TEST_DRIVER_NATIONALITIES[key]) {
+    return TEST_DRIVER_NATIONALITIES[key];
+  }
+  for (const [name, nationality] of Object.entries(TEST_DRIVER_NATIONALITIES)) {
+    const normalized = name.replace(/[\s'-]/g, ' ').replace(/\s+/g, ' ').trim();
+    if (key.includes(normalized) || normalized.includes(key)) {
+      return nationality;
+    }
+  }
+  return null;
+}
+
+export interface TestDriverEntry {
+  number: string;
+  name: string;
+  flag: string;
+  constructorId: string;
+}
+
+export function detectTestDriversFromFp1(
+  mainDrivers: Driver[],
+  fp1: Record<string, PracticeSessionData> | null
+): TestDriverEntry[] {
+  if (!fp1 || Object.keys(fp1).length === 0) return [];
+
+  const mainDriverKeys = new Set<string>();
+  for (const driver of mainDrivers) {
+    mainDriverKeys.add(driver.driverId.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
+  }
+
+  const testDrivers: TestDriverEntry[] = [];
+  const seen = new Set<string>();
+
+  for (const data of Object.values(fp1)) {
+    const name = data.driverName;
+    const cleanName = name.toLowerCase().replace(/[\s'-]/g, '');
+    if (mainDriverKeys.has(name.toLowerCase()) || mainDriverKeys.has(cleanName)) {
+      continue;
+    }
+    if (seen.has(cleanName)) continue;
+    seen.add(cleanName);
+
+    const constructorId = teamNameToConstructorId(data.teamName) || '';
+    const nationality = lookupTestDriverNationality(name);
+    const flag = nationality ? getFlag(nationality) : '{{FIA}}';
+
+    testDrivers.push({
+      number: data.number,
+      name,
+      flag,
+      constructorId,
+    });
+  }
+
+  return testDrivers.sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
+}
+
+const ENTRY_LIST_HEADING_VARIANTS = [
+  '==Entry List==',
+  '== Entry List ==',
+  '===Entry List===',
+  '=== Entry List ===',
+];
+
+export function findEntryListHeadingIndex(wikitext: string): number {
+  let bestIndex = -1;
+  for (const variant of ENTRY_LIST_HEADING_VARIANTS) {
+    const idx = wikitext.indexOf(variant);
+    if (idx !== -1 && (bestIndex === -1 || idx < bestIndex)) {
+      bestIndex = idx;
+    }
+  }
+  return bestIndex;
+}
+
+export function addTestDriversToEntryList(wikitext: string, testDrivers: TestDriverEntry[]): string {
+  if (testDrivers.length === 0) return wikitext;
+
+  const headingIndex = findEntryListHeadingIndex(wikitext);
+  if (headingIndex === -1) return wikitext;
+
+  const afterHeading = wikitext.slice(headingIndex);
+  const newDrivers = testDrivers.filter(td => {
+    const nameLower = td.name.toLowerCase();
+    return !afterHeading.toLowerCase().includes(`[[${nameLower}]]`) &&
+      !afterHeading.toLowerCase().includes(td.name.toLowerCase());
+  });
+
+  if (newDrivers.length === 0) return wikitext;
+
+  const sourceMarkers = [
+    '! colspan="8" align="center" |\'\'\'Source\'\'\'',
+    '! colspan="8" | Source:',
+    '! colspan="8" align="center" |Source',
+  ];
+
+  let insertIndex = -1;
+  for (const marker of sourceMarkers) {
+    const idx = afterHeading.indexOf(marker);
+    if (idx !== -1) {
+      insertIndex = headingIndex + idx;
+      break;
+    }
+  }
+
+  if (insertIndex === -1) {
+    const closeIdx = afterHeading.indexOf('|}');
+    if (closeIdx === -1) return wikitext;
+    insertIndex = headingIndex + closeIdx;
+  }
+
+  let rows = '\n|-\n|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
+  for (const td of newDrivers) {
+    const team = td.constructorId ? getTeamEntryDetails(td.constructorId) : null;
+    const entrant = team ? team.entrant : '';
+    const constructor = team ? team.constructor : '';
+    const chassis = team ? team.chassis : '';
+    const engine = team ? team.engine : '';
+    const model = team ? team.model : '';
+    const tyre = team ? team.tyre : '{{Pirelli}}';
+
+    rows += `\n|-\n!${td.number}\n|${td.flag} [[${td.name}]]\n|${entrant}\n|${constructor}\n|${chassis}\n|${engine}\n|${model}\n|${tyre}`;
+  }
+
+  return wikitext.slice(0, insertIndex) + rows + '\n' + wikitext.slice(insertIndex);
+}
 
 const MONTH_NAMES = [
   "January", "February", "March", "April", "May", "June",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expands the automatic Cloudflare Worker cron sync to handle practice session results (FP1/FP2/FP3), LLM-generated practice reports using crawled F1.com articles, and automatic test driver entry list updates on the F1 Fandom Wiki.

## Changes

### Sync state (`src/sync-kv.ts`)
- Added `practice_results_fp1/fp2/fp3` and `fp1/fp2/fp3_report` KV section types
- Updated `gpPageSectionRequired` to gate sections on practice session conclusion times and sprint weekend status

### Wiki generation (`src/wikitext-generator.ts`)
- `generatePracticeWikitext` now supports sprint weekends (FP1-only columns) and renders test drivers from scraped results
- Added `addTestDriversToEntryList` using `indexOf`-based heading lookup (ReDoS-safe)
- Added test driver detection, nationality lookup, and team name mapping helpers

### LLM reporting (`src/llm-reporter.ts`)
- `generatePromptContext` accepts optional practice session results
- Added `fetchF1comSessionArticle` to crawl official F1.com race page articles
- FP1/FP2/FP3 prompts highlight incidents, spins, mechanical issues, and driver feedback
- Crawler failures logged to `f1_crawler_failures` KV key

### Cron worker (`src/index.ts`)
- Calculates FP1/FP2/FP3 conclusion times (session start + 1 hour)
- Dynamically resolves 2026 F1.com race IDs (`1278 + round` for R1–3, `1280 + round` for R4–22)
- Scrapes concluded practice sessions, updates practice results table, appends test drivers to entry list, and generates FP reports
- Skips KV sync when scraped results are empty (retry on next cron run)
- Daily summary email includes warnings for unknown test driver flags and crawler failures

### Python CLI (`f1.py`)
- Updated `scrape_f1_practice_data` to use the same 2026 race ID formula as the TypeScript worker

## Verification

- `npx tsc --noEmit` — passes
- `npx tsx scripts/verify-sync-kv.ts` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

