### PR TITLE
Add verification test suite and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # F1 Fandom Wiki Automator
 
-A comprehensive automation tool for generating and maintaining Formula One Wiki tables on [f1.fandom.com](https://f1.fandom.com). This project combines **TypeScript** (55.5%) and **Python** (44.5%) to create fully formatted WikiTables for Grand Prix articles.
+A comprehensive automation tool for generating and maintaining Formula One Wiki tables on [f1.fandom.com](https://f1.fandom.com). This project combines **TypeScript** (Cloudflare Workers) and **Python** to create fully formatted WikiTables for Grand Prix articles.
 
 ## Features
 
@@ -18,9 +18,12 @@ A comprehensive automation tool for generating and maintaining Formula One Wiki 
 - **Latest News & Events Sync**: Periodically compiles the previous, latest, and upcoming event schedules and updates `Template:Latest_F1_News/Events`.
 - **Career Standing Templates Sync**: Automatically keeps the F1 Fandom career standing templates (`Template:Career_Results/Points/2026`, `Template:Career_Results/Position/2026`, and `Template:Career_Results/Team_Position/2026`) synchronized with the latest standings from the Jolpi API.
 - **Concluded Sessions Polling**: Automatically checks KV caches and conclusion status for completed Grand Prix and Sprint sessions, polling results and deploying them to wiki templates as soon as they become available.
+- **Practice Session Automation**: Scrapes F1.com practice results (FP1, FP2, FP3) during active race weekends, updates the GP page practice results table incrementally, and retries automatically when results are not yet published.
+- **Test Driver Entry List Updates**: Detects rookie test drivers appearing in FP1 who are not on the main entry list and appends them to the wiki Entry List section with team details from `TEAM_DETAILS_2026`.
 - **Scheduled Stats Sync**: Automatically computes and synchronizes career stats templates once a race weekend's Grand Prix results are published.
 - **Automated Infobox Updates**: Dynamically populates parameters in race infoboxes (`Infobox_Race` or `Infobox Sprint Race`) for qualifying pole, sprint standings, race winners, podium finishes, and fastest laps as sessions conclude.
-- **LLM-Powered Section Reports**: Automatically drafts and publishes factual, neutral, encyclopedia-style reports for section headings (`Background`, `Q1`, `Q2`, `Q3`, `Sprint Report`, and `Race Report`) using an LLM. Features native **Cloudflare Workers AI** (Llama 3) support with failover to **Google Gemini** or **OpenAI** APIs. Checks and safeguards sections to ensure human edits are never overwritten.
+- **LLM-Powered Section Reports**: Automatically drafts and publishes factual, neutral, encyclopedia-style reports for section headings (`Background`, `FP1`, `FP2`, `FP3`, `Q1`, `Q2`, `Q3`, `Sprint Report`, and `Race Report`) using an LLM. Practice reports crawl official F1.com session articles for richer context. Features native **Cloudflare Workers AI** (Llama 3) support with failover to **Google Gemini** or **OpenAI** APIs. Checks and safeguards sections to ensure human edits are never overwritten.
+- **Per-Section KV Sync State**: Each GP page section, career template, and stats template has its own Cloudflare KV flag so one successful sync cannot block retries for another target.
 
 ### Wiki Career Stats Tracking
 - **Cumulative Stat Compilations**: Combines 2025 career baseline data with 2026 round-by-round statistics to track cumulative progress.
@@ -35,35 +38,39 @@ A comprehensive automation tool for generating and maintaining Formula One Wiki 
 
 ### Daily Reporting
 - **Operations Summary Emails**: Integrates with Resend API to deliver a daily report (at 6 AM Pacific Time) to administrators detailing total attempted, succeeded, and failed API actions, including a detailed error log with reasons for any failures.
+- **Operational Warnings**: Alerts administrators about unknown test driver nationality flags and F1.com article crawler failures encountered during practice report generation.
 
 ### Data Processing
-- **Smart Caching**: Caches per-round statistics and results in Cloudflare KV to minimize subrequests and stay within API rate limits.
+- **Smart Caching**: Caches per-round statistics and results in Cloudflare KV to minimize subrequests and stay within API rate limits. Within-run Jolpica API deduplication and 429 backoff reduce redundant fetches during cron execution.
 - **Driver Name Mapping**: Map and standardize driver/constructor names and keys across different data sources (supporting lowercase key matching).
 - **Time Calculations**: Calculate 107% qualifying times and convert time differentials to absolute times.
 - **Flag and Constructor Templates**: Automated nationality-to-flag-template conversion for 25+ countries and constructor mapping.
+- **2026 F1.com Race ID Resolution**: Dynamically resolves F1.com practice URL race IDs for the 2026 season (`1278 + round` for Rounds 1–3, `1280 + round` for Rounds 4–22).
 
 ### Python Utilities
 - **Legacy Python Scripts**: Original Python-based wiki table generation with Pandas integration.
 - **Ergast Data Handling**: Python wrapper for Ergast F1 API data processing.
-- **Web Scraping**: BeautifulSoup integration for practice session data collection.
+- **Web Scraping**: BeautifulSoup integration for practice session data collection (aligned with TypeScript 2026 race ID formula).
 - **Status Code Handling**: Proper handling of race status codes (Retired, Disqualified, DNS, etc.).
 
 ## Technology Stack
 
 - **Backend**: TypeScript (Cloudflare Workers)
-- **Data Sources**: Jolpi F1 API (Ergast-compatible)
+- **Data Sources**: Jolpi F1 API (Ergast-compatible), F1.com (practice results and session articles)
 - **Wiki Integration**: MediaWiki API
 - **Frontend**: HTML5, CSS3, Vanilla JavaScript (tabs and real-time logs)
 - **Python Tools**: Pandas, Requests, BeautifulSoup
-- **Security**: Cloudflare Turnstile verification
+- **Security**: Cloudflare Turnstile verification, CodeQL-safe line-based wikitext parsing
 - **Storage**: Cloudflare KV (state tracking and logging)
 - **Notifications**: Resend API (email reports)
+- **AI**: Cloudflare Workers AI, Google Gemini Flash, OpenAI (with automatic provider fallback)
 
 ## Use Cases
 
 - Automated wiki article updates after each F1 race weekend.
 - Scheduled synchronization of news templates and season standings.
 - Batch updates of driver career stats templates with cumulative season numbers.
+- Automated practice results tables and FP session reports during race weekends.
 - Automated monitoring and reporting of worker operations.
 - Interactively previewing and deploying wikitext templates using a visual dashboard.
 
@@ -72,12 +79,23 @@ A comprehensive automation tool for generating and maintaining Formula One Wiki 
 ```
 f1-fandom/
 ├── src/
-│   ├── index.ts              # Main Cloudflare Worker handler
-│   ├── f1-api.ts             # Ergast/Jolpi API integration
+│   ├── index.ts              # Main Cloudflare Worker handler and cron sync
+│   ├── f1-api.ts             # Jolpi API integration and F1.com helpers
+│   ├── f1-api-cache.ts       # Within-run API deduplication and 429 backoff
+│   ├── sync-kv.ts            # Per-target KV sync flag helpers
 │   ├── wiki.ts               # MediaWiki API integration
-│   ├── wikitext-generator.ts # WikiTable formatting
-│   ├── stats.ts              # Driver career statistics and templates calculations
+│   ├── wikitext-generator.ts # WikiTable formatting and test driver helpers
+│   ├── wikitext-parse.ts     # CodeQL-safe line-based wikitext parsing
+│   ├── llm-reporter.ts       # LLM prompts, F1.com article crawling, HTML sanitization
+│   ├── stats.ts              # Driver career statistics and template calculations
 │   └── frontend-html.ts      # Web dashboard UI
+├── scripts/
+│   ├── verify-sync-kv.ts           # KV sync flag smoke tests
+│   ├── verify-wikitext-parse.ts    # Wikitext parsing verification
+│   ├── verify-infobox-update.ts    # Infobox parameter read/update tests
+│   ├── verify-jolpica-cache.ts     # API cache dedup and backoff tests
+│   ├── verify-practice-sessions.ts # Practice scraping and test driver tests
+│   └── verify-llm-reporter.ts      # HTML sanitization and prompt context tests
 ├── f1.py                     # Python wiki table generator
 ├── pyergast.py               # Python Ergast API wrapper
 └── README.md
@@ -91,28 +109,49 @@ f1-fandom/
 4. Use the web dashboard or API endpoints to trigger updates
 5. Verify generated wikitext before publishing to wiki
 
+### Running Tests
+
+```bash
+npm test
+```
+
+This runs the TypeScript compiler (`tsc --noEmit`) and all verification scripts in `scripts/`.
+
 ## Recent Updates & Changelog
 
-Here is a summary of the improvements and fixes made in recent commits:
+Summary of improvements since the last README update (June 7, 2026):
 
-### Automated Reporting & Content Generation
-- **LLM-Powered Section Writing**: Added support for generating factual, neutral wikitext reports for GP sections (`Background`, `Q1`, `Q2`, `Q3`, `Sprint Report`, `Race Report`) using Llama 3, Google Gemini, or OpenAI with automatic fallback checks and custom edit safeguarding.
-- **Dynamic Infobox Updating**: Automatically updates pole times, podium finishers, nations, team templates, and fastest laps inside the GP article's infobox.
+### Practice Sessions & Test Drivers (June 2026)
+- **Automated Practice Scraping**: Cron worker scrapes F1.com FP1/FP2/FP3 results during active race weekends and updates the GP page practice results table incrementally.
+- **LLM Practice Reports**: Generates FP1, FP2, and FP3 section reports using crawled official F1.com session articles, with prompts highlighting incidents, spins, mechanical issues, and driver feedback.
+- **Test Driver Entry List**: Detects test drivers in FP1 results and appends them to the wiki Entry List with team details; unknown nationalities default to `{{FIA}}` and trigger a daily email warning.
+- **Empty Results Retry**: Skips KV sync when F1.com has not yet published results, allowing automatic retry on the next 10-minute cron execution.
+- **2026 Race ID Formula**: Dynamic F1.com race ID resolution (`1278 + round` for Rounds 1–3, `1280 + round` for Rounds 4–22) in both TypeScript worker and Python CLI.
+- **Sprint Weekend Support**: Practice results table shows FP1 only on sprint weekends.
 
-### Stats, Standings & Caching Improvements
-- **Stats Cache Validation & Force-Refresh**: Added stats cache validation logic so cached rounds are only saved after race results are confirmed (preventing premature caching of qualifying data). Added a "Refresh Stats Cache" button to clear KV round keys and recompute.
-- **Fallback Grid Positions**: Improved race result parsing by automatically falling back to qualifying positions if grid values from the API are missing/null.
-- **Dynamic Points Formatting**: Implemented dynamic rowspans for points blanks, hiding "0" points and resolving table layout colspan issues.
-- **StatsF1 Verification**: Added verification steps to check classification results against StatsF1 and highlight mismatches in the dashboard.
+### Sync Reliability & Performance (June 2026)
+- **Per-Target KV Sync Flags** (`sync-kv.ts`): Replaced monolithic `gp_updated` flag with dedicated flags per GP page section, career template, stats template, and standings template — preventing one successful sync from blocking retries for another target.
+- **Jolpica API Optimization**: Added within-run request deduplication, 429 backoff with `Retry-After`, round-level KV early-skip, and batched `fetchRoundJolpicaData` to reduce API calls during cron runs.
+- **Events Sync Sanity Check**: Prevents `Template:Latest_F1_News/Events` from reverting to stale prior-season data when adjacent-year schedule fetches fail.
 
-### Wiki Integration & Robustness
-- **Failsafe Heading Replacement**: Refactored heading detection and section replacement logic to support flexible, fuzzy spacing and levels in wikitext headings.
-- **Blank GP Page Generation**: Added worker API endpoint and frontend dashboard button to generate a clean wikitext draft for upcoming GP pages.
-- **Constructor & Track Mapping Refinements**:
-  - Mapped 'Brazilian Grand Prix' to 'São Paulo Grand Prix' (from 2021 onwards) to match wiki page titles.
-  - Mapped 'Barcelona Grand Prix' to 'Barcelona-Catalunya Grand Prix' (for the 2026 season).
-  - Updated constructors to support Revolut Audi F1 Team and Cadillac Formula 1 Team templates.
-- **CAPTCHA Stability**: Fixed Turnstile verification issues in frontend forms by adding resets in finally blocks.
+### Security & Code Quality (June 2026)
+- **CodeQL ReDoS Fixes**: Replaced polynomial regex on wikitext with line-based parsing helpers in `wikitext-parse.ts`, `wiki.ts`, `stats.ts`, and `index.ts`.
+- **HTML Sanitization**: Practice article text extraction uses loop-until-stable tag stripping with residual angle-bracket removal to prevent incomplete multi-character sanitization alerts.
+- **ReDoS-Safe Entry List Matching**: Test driver entry list heading lookup uses `indexOf` instead of regular expressions on untrusted wikitext.
+
+### Infobox & Wiki Robustness (June 2026)
+- **Infobox Parameter Parsing**: Line-based infobox read/update prevents `}}}}` corruption when template values contain nested `}}` braces.
+- **Infobox Cron Safeguard**: Skips overwriting infobox parameters that already have values, preserving human edits.
+- **FIA Practice Classification URLs**: Updated practice results source ref URLs to match current FIA document naming.
+
+### Earlier Improvements (also since last README update)
+- **LLM-Powered Section Writing**: Factual wikitext reports for GP sections using Llama 3, Google Gemini Flash, or OpenAI with automatic fallback and human-edit safeguarding.
+- **Dynamic Infobox Updating**: Pole times, podium finishers, nations, team templates, and fastest laps populated as sessions conclude.
+- **Stats Cache Validation & Force-Refresh**: Only caches round stats after race results are confirmed; dashboard "Refresh Stats Cache" button clears stale KV keys.
+- **StatsF1 Verification**: Classification cross-check against StatsF1 with mismatch highlighting in the dashboard.
+- **Blank GP Page Generation**: API endpoint and dashboard button to generate clean wikitext drafts for upcoming GPs.
+- **Constructor & Track Mapping**: São Paulo GP rename (2021+), Barcelona-Catalunya GP (2026), Revolut Audi and Cadillac team templates.
+- **Dependabot**: Automated dependency update PRs configured via `.github/dependabot.yml`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/index.ts",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "build": "tsc --noEmit",
+    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240320.0",

--- a/scripts/verify-llm-reporter.ts
+++ b/scripts/verify-llm-reporter.ts
@@ -1,0 +1,58 @@
+/**
+ * Verifies LLM reporter HTML sanitization and prompt context helpers.
+ * Run: npx tsx scripts/verify-llm-reporter.ts
+ */
+import { generatePromptContext, stripHtmlTags } from '../src/llm-reporter';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+// --- CodeQL-safe HTML tag stripping ---
+const nestedTagPayload = '<scri<x>pt>alert(1)</scri<x>pt>';
+const stripped = stripHtmlTags(nestedTagPayload);
+assert(!stripped.includes('<'), 'No angle brackets should remain');
+assert(!stripped.includes('script'), 'Script tag content should be removed or neutralized');
+
+const normalHtml = '<strong>Fastest lap</strong> set by <a href="#">driver</a>';
+assert(stripHtmlTags(normalHtml) === 'Fastest lap set by driver', 'Normal HTML stripped to plain text');
+
+const multiPass = '<span><em>nested</em></span>';
+assert(stripHtmlTags(multiPass) === 'nested', 'Nested tags fully removed');
+
+// --- Practice results in prompt context ---
+const race = {
+  season: '2026',
+  round: '8',
+  raceName: 'Austrian Grand Prix',
+  Circuit: {
+    circuitName: 'Red Bull Ring',
+    Location: { locality: 'Spielberg', country: 'Austria' },
+  },
+};
+
+const context = generatePromptContext(
+  race,
+  [],
+  {},
+  [],
+  [],
+  [],
+  {
+    fp1: {
+      'Lando Norris': {
+        position: '1',
+        number: '4',
+        driverName: 'Lando Norris',
+        teamName: 'McLaren',
+        time: '1:23.456',
+      },
+    },
+  }
+);
+
+assert(context.includes('### FP1 Results:'), 'Prompt context includes FP1 section');
+assert(context.includes('Lando Norris'), 'Prompt context includes driver from practice results');
+assert(context.includes('Austrian Grand Prix'), 'Prompt context includes race name');
+
+console.log('verify-llm-reporter: all assertions passed');

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -1,0 +1,128 @@
+/**
+ * Verifies practice session scraping helpers, wikitext generation, and test driver entry list logic.
+ * Run: npx tsx scripts/verify-practice-sessions.ts
+ */
+import { buildPracticeSessionUrl, getF1comRaceId } from '../src/f1-api';
+import {
+  addTestDriversToEntryList,
+  detectTestDriversFromFp1,
+  findEntryListHeadingIndex,
+  generatePracticeWikitext,
+} from '../src/wikitext-generator';
+import { gpPageSectionRequired } from '../src/sync-kv';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+// --- 2026 F1.com race ID resolution ---
+assert(getF1comRaceId(2026, 1) === '1279', 'Round 1 Australia = 1279');
+assert(getF1comRaceId(2026, 3) === '1281', 'Round 3 Japan = 1281');
+assert(getF1comRaceId(2026, 4) === '1284', 'Round 4 Miami = 1284');
+assert(getF1comRaceId(2026, 8) === '1288', 'Round 8 Austria = 1288');
+
+const fp1Url = buildPracticeSessionUrl(2026, 8, 'Austrian Grand Prix', 1);
+assert(
+  fp1Url === 'https://www.formula1.com/en/results/2026/races/1288/austrian-grand-prix/practice/1',
+  `Unexpected practice URL: ${fp1Url}`
+);
+
+// --- GP page section required states for practice ---
+const sprintTiming = {
+  hasSprint: true,
+  isQualiConcluded: false,
+  isSprintConcluded: false,
+  isRaceConcluded: false,
+  isFp1Concluded: true,
+  isFp2Concluded: true,
+  isFp3Concluded: true,
+};
+
+assert(gpPageSectionRequired('practice_results_fp1', sprintTiming), 'FP1 required on sprint weekend');
+assert(gpPageSectionRequired('fp1_report', sprintTiming), 'FP1 report required on sprint weekend');
+assert(!gpPageSectionRequired('practice_results_fp2', sprintTiming), 'FP2 not required on sprint weekend');
+assert(!gpPageSectionRequired('practice_results_fp3', sprintTiming), 'FP3 not required on sprint weekend');
+
+const normalTiming = { ...sprintTiming, hasSprint: false };
+assert(gpPageSectionRequired('practice_results_fp2', normalTiming), 'FP2 required on normal weekend');
+assert(gpPageSectionRequired('practice_results_fp3', normalTiming), 'FP3 required on normal weekend');
+
+// --- Test driver detection ---
+const mainDrivers = [
+  {
+    driverId: 'norris',
+    givenName: 'Lando',
+    familyName: 'Norris',
+    permanentNumber: '4',
+    nationality: 'British',
+    code: 'NOR',
+  },
+];
+
+const fp1WithTestDriver = {
+  'Lando Norris': {
+    position: '1',
+    number: '4',
+    driverName: 'Lando Norris',
+    teamName: 'McLaren',
+    time: '1:23.456',
+  },
+  'Patricio O Ward': {
+    position: '12',
+    number: '98',
+    driverName: 'Patricio O Ward',
+    teamName: 'McLaren',
+    time: '1:25.123',
+  },
+};
+
+const testDrivers = detectTestDriversFromFp1(mainDrivers as any, fp1WithTestDriver);
+assert(testDrivers.length === 1, 'Should detect one test driver');
+assert(testDrivers[0].name === 'Patricio O Ward', 'Test driver name');
+assert(testDrivers[0].constructorId === 'mclaren', 'Test driver team mapping');
+assert(testDrivers[0].flag === '{{MEX}}', 'Test driver nationality flag');
+
+// --- Entry list heading lookup (ReDoS-safe indexOf) ---
+const entryListPage = `===Entry List===
+{| class="wikitable"
+!No.
+|-
+! colspan="8" align="center" |'''Source''': ref
+|}`;
+
+assert(findEntryListHeadingIndex(entryListPage) === 0, 'Should find ==Entry List==');
+assert(findEntryListHeadingIndex('== Entry List ==\ncontent') === 0, 'Should find spaced variant');
+
+const withTestDriverRows = addTestDriversToEntryList(entryListPage, testDrivers);
+assert(withTestDriverRows.includes('[[Test Driver]]s for [[#FP1|Practice 1]]'), 'Test driver header row');
+assert(withTestDriverRows.includes('[[Patricio O Ward]]'), 'Test driver name in entry list');
+assert(withTestDriverRows.indexOf('[[Test Driver]]') < withTestDriverRows.indexOf("'''Source'''"), 'Inserted before source row');
+
+const unchanged = addTestDriversToEntryList(withTestDriverRows, testDrivers);
+assert(unchanged === withTestDriverRows, 'Should not duplicate existing test drivers');
+
+// --- Practice wikitext sprint vs normal weekend ---
+const practiceWikitextSprint = generatePracticeWikitext(
+  mainDrivers as any,
+  null,
+  fp1WithTestDriver,
+  null,
+  null,
+  { hasSprint: true }
+);
+assert(practiceWikitextSprint.includes('|FP1'), 'Sprint weekend includes FP1 column');
+assert(!practiceWikitextSprint.includes('|FP2'), 'Sprint weekend excludes FP2 column');
+assert(practiceWikitextSprint.includes('[[Patricio O Ward]]'), 'Sprint practice table includes test driver');
+
+const practiceWikitextNormal = generatePracticeWikitext(
+  mainDrivers as any,
+  null,
+  fp1WithTestDriver,
+  fp1WithTestDriver,
+  null,
+  { hasSprint: false }
+);
+assert(practiceWikitextNormal.includes('|FP2'), 'Normal weekend includes FP2 column');
+assert(practiceWikitextNormal.includes('|FP3'), 'Normal weekend includes FP3 column');
+
+console.log('verify-practice-sessions: all assertions passed');

--- a/scripts/verify-sync-kv.ts
+++ b/scripts/verify-sync-kv.ts
@@ -40,6 +40,30 @@ assert(
   gpPageSectionKey(7, 'race_results') === '2026_round_7_gp_page_race_results_synced',
   'GP page section key'
 );
+assert(
+  gpPageSectionKey(7, 'practice_results_fp1') === '2026_round_7_gp_page_practice_results_fp1_synced',
+  'Practice FP1 section key'
+);
+assert(
+  gpPageSectionKey(7, 'fp3_report') === '2026_round_7_gp_page_fp3_report_synced',
+  'FP3 report section key'
+);
+
+const fpOnlyTiming = {
+  hasSprint: false,
+  isQualiConcluded: false,
+  isSprintConcluded: false,
+  isRaceConcluded: false,
+  isFp1Concluded: true,
+  isFp2Concluded: false,
+  isFp3Concluded: false,
+};
+assert(gpPageSectionRequired('practice_results_fp1', fpOnlyTiming), 'FP1 practice required when concluded');
+assert(!gpPageSectionRequired('practice_results_fp2', fpOnlyTiming), 'FP2 not required before conclusion');
+assert(
+  !gpPageSectionRequired('fp2_report', { ...fpOnlyTiming, hasSprint: true, isFp2Concluded: true }),
+  'FP2 report not required on sprint weekend'
+);
 
 const timing = {
   hasSprint: true,

--- a/src/llm-reporter.ts
+++ b/src/llm-reporter.ts
@@ -183,7 +183,7 @@ function scoreArticleRelevance(slug: string, sessionName: string): number {
   return score;
 }
 
-function stripHtmlTags(input: string): string {
+export function stripHtmlTags(input: string): string {
   let prev: string;
   let result = input;
   do {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a unified verification test suite and updates the README to document all project changes since June 7, 2026.

## Changes

### Tests
- Added `scripts/verify-practice-sessions.ts` — 2026 race IDs, practice wikitext, test driver detection, entry list insertion
- Added `scripts/verify-llm-reporter.ts` — HTML sanitization and prompt context with practice results
- Expanded `scripts/verify-sync-kv.ts` with practice section KV keys and timing assertions
- Added `npm test` (runs `tsc --noEmit` + all 6 verify scripts) and `npm build` to `package.json`
- Exported `stripHtmlTags` from `llm-reporter.ts` for testability

### Documentation
- Updated `README.md` with practice session automation, per-target KV sync, Jolpica API optimization, security fixes, project structure, and testing instructions

## Verification

```bash
npm test
```

All 6 verification scripts pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

