### PR TITLE
Limit edit retries and reduce KV write usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
-    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts"
+    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240320.0",

--- a/scripts/verify-kv-ops.ts
+++ b/scripts/verify-kv-ops.ts
@@ -1,0 +1,112 @@
+/**
+ * Verifies KV batching, edit failure limits, and daily put counting.
+ * Run: npx tsx scripts/verify-kv-ops.ts
+ */
+import {
+  beginKvInvocation,
+  bufferApiLog,
+  bufferKvWarning,
+  clearEditFailures,
+  editFailureKey,
+  endKvInvocation,
+  getDailyKvPutCount,
+  getEditFailureCount,
+  isEditBlocked,
+  MAX_EDIT_FAILURES,
+  PROXY_LOGS_KEY,
+  recordEditFailure,
+  trackedKvPut,
+} from '../src/kv-ops';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+function createMockKv(): { store: Map<string, string>; get: (k: string) => Promise<string | null>; put: (k: string, v: string) => Promise<void>; delete: (k: string) => Promise<void> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async get(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  };
+}
+
+async function testBufferedApiLogs(): Promise<void> {
+  const kv = createMockKv();
+  beginKvInvocation();
+  bufferApiLog({ action: 'Test', method: 'GET', url: 'http://test', success: true, errorReason: null });
+  bufferApiLog({ action: 'Test 2', method: 'POST', url: 'http://test', success: false, errorReason: 'fail' });
+  await endKvInvocation(kv);
+
+  const logs = JSON.parse(kv.store.get(PROXY_LOGS_KEY) || '[]');
+  assert(logs.length === 2, 'Should batch two API logs into one KV put');
+  assert(kv.store.size >= 1, 'Should have written proxy logs key');
+}
+
+async function testDailyPutCounter(): Promise<void> {
+  const kv = createMockKv();
+  beginKvInvocation();
+  await trackedKvPut(kv, 'sync_flag_a', 'true');
+  await trackedKvPut(kv, 'sync_flag_b', 'true');
+  await endKvInvocation(kv);
+
+  const count = await getDailyKvPutCount(kv);
+  assert(count >= 2, `Daily KV put counter should include invocation puts, got ${count}`);
+}
+
+async function testEditFailureLimit(): Promise<void> {
+  const kv = createMockKv();
+  const title = '2026 Austrian Grand Prix';
+
+  for (let i = 0; i < MAX_EDIT_FAILURES; i++) {
+    assert(!await isEditBlocked(kv, title), `Should not block before ${MAX_EDIT_FAILURES} failures`);
+    await recordEditFailure(kv, title);
+  }
+
+  assert(await isEditBlocked(kv, title), 'Should block after max failures');
+  assert(
+    (await getEditFailureCount(kv, title)) === MAX_EDIT_FAILURES,
+    'Failure count should equal max'
+  );
+
+  await clearEditFailures(kv, title);
+  assert(!await isEditBlocked(kv, title), 'Should unblock after clear');
+  assert(!kv.store.has(editFailureKey(title)), 'Failure key should be deleted');
+}
+
+async function testBufferedWarnings(): Promise<void> {
+  const kv = createMockKv();
+  beginKvInvocation();
+  bufferKvWarning('missing_test_driver_flags', 'Unknown flag for Driver X');
+  bufferKvWarning('f1_crawler_failures', 'Crawler failed for FP1');
+  await endKvInvocation(kv);
+
+  const flags = JSON.parse(kv.store.get('missing_test_driver_flags') || '[]');
+  const crawlers = JSON.parse(kv.store.get('f1_crawler_failures') || '[]');
+  assert(flags.length === 1, 'Should batch test driver flag warnings');
+  assert(crawlers.length === 1, 'Should batch crawler warnings');
+}
+
+async function main(): Promise<void> {
+  await testBufferedApiLogs();
+  console.log('PASS: buffered API logs');
+  await testDailyPutCounter();
+  console.log('PASS: daily KV put counter');
+  await testEditFailureLimit();
+  console.log('PASS: edit failure limit');
+  await testBufferedWarnings();
+  console.log('PASS: buffered KV warnings');
+  console.log('verify-kv-ops: all assertions passed');
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err.message);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,14 @@ import {
   CareerStandingsPage,
   GpPageSection,
 } from './sync-kv';
+import {
+  beginKvInvocation,
+  endKvInvocation,
+  getDailyKvPutCount,
+  getPacificDateString,
+  KV_FREE_TIER_DAILY_WRITE_LIMIT,
+  trackedKvPut,
+} from './kv-ops';
 
 // CORS response helper
 function corsResponse(body: string | object, status = 200, headers: Record<string, string> = {}): Response {
@@ -138,6 +146,7 @@ export default {
       return corsResponse('', 204);
     }
 
+    beginKvInvocation();
     try {
       const apiCtx = createF1ApiContext();
 
@@ -568,25 +577,28 @@ export default {
 
     } catch (e: any) {
       return corsResponse({ error: e.message }, 500);
+    } finally {
+      await endKvInvocation(_env.F1_WIKI_STATE);
     }
   },
 
   async scheduled(event: any, env: any, _ctx: any): Promise<void> {
-    const cronTrigger = event?.cron || "";
-    console.log(`Scheduled sync trigger fired! Trigger: ${cronTrigger || "manual/unknown"}`);
-
-    const username = env.WIKI_BOT_USERNAME;
-    const password = env.WIKI_BOT_PASSWORD;
-    const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
-    const apiEndpoint = env.WIKI_API_ENDPOINT;
-    const proxySecret = env.PROXY_SECRET;
-
-    if (!username || !password) {
-      console.error("Sync cancelled: Bot credentials (WIKI_BOT_USERNAME or WIKI_BOT_PASSWORD) not found in secrets.");
-      return;
-    }
-
+    beginKvInvocation();
     try {
+      const cronTrigger = event?.cron || "";
+      console.log(`Scheduled sync trigger fired! Trigger: ${cronTrigger || "manual/unknown"}`);
+
+      const username = env.WIKI_BOT_USERNAME;
+      const password = env.WIKI_BOT_PASSWORD;
+      const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
+      const apiEndpoint = env.WIKI_API_ENDPOINT;
+      const proxySecret = env.PROXY_SECRET;
+
+      if (!username || !password) {
+        console.error("Sync cancelled: Bot credentials (WIKI_BOT_USERNAME or WIKI_BOT_PASSWORD) not found in secrets.");
+        return;
+      }
+
       const apiCtx = createF1ApiContext();
       console.log("Fetching 2026 schedule from Jolpi...");
       const year = 2026;
@@ -1338,6 +1350,8 @@ export default {
       console.log(`Scheduled sync completed successfully! Jolpica API calls this run: ${apiCtx.apiCallCount}`);
     } catch (e: any) {
       console.error("Scheduled sync failed:", e.message);
+    } finally {
+      await endKvInvocation(env.F1_WIKI_STATE);
     }
   }
 };
@@ -1547,22 +1561,13 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
   if (!kv || !resendApiKey) return;
 
   // Get current date/time in America/Los_Angeles timezone (Pacific Time)
+  const pacificDateStr = getPacificDateString();
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Los_Angeles',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
     hour: '2-digit',
     hour12: false
   });
-
-  const parts = formatter.formatToParts(new Date());
-  const year = parts.find(p => p.type === 'year')?.value;
-  const month = parts.find(p => p.type === 'month')?.value;
-  const day = parts.find(p => p.type === 'day')?.value;
-  const hourStr = parts.find(p => p.type === 'hour')?.value || '0';
-  
-  const pacificDateStr = `${year}-${month}-${day}`; // YYYY-MM-DD
+  const hourStr = formatter.formatToParts(new Date()).find(p => p.type === 'hour')?.value || '0';
   const pacificHour = parseInt(hourStr, 10);
 
   // We want to send the summary at 6 AM Pacific Time or later, if not sent today yet
@@ -1581,6 +1586,12 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
       const succeededCalls = logs.filter((l: any) => l.success).length;
       const failedCalls = totalCalls - succeededCalls;
       const failedLogs = logs.filter((l: any) => !l.success);
+      const kvPutCount = await getDailyKvPutCount(kv, pacificDateStr);
+      const kvPutPercent = Math.min(
+        100,
+        Math.round((kvPutCount / KV_FREE_TIER_DAILY_WRITE_LIMIT) * 100)
+      );
+      const kvUsageColor = kvPutPercent >= 80 ? '#dc2626' : kvPutPercent >= 50 ? '#d97706' : '#059669';
 
       let failedSection = '';
       if (failedLogs.length > 0) {
@@ -1682,6 +1693,17 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
                   </tr>
                 </table>
 
+                <h2 style="margin: 24px 0 12px 0; color: #1f2937; font-size: 18px; font-weight: 600; border-bottom: 1px solid #e5e7eb; padding-bottom: 8px;">KV Usage</h2>
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" style="margin-bottom: 24px; width: 100%;">
+                  <tr>
+                    <td style="padding: 16px; background-color: #f3f4f6; border-radius: 8px; text-align: center; border: 1px solid #e5e7eb;">
+                      <div style="color: #4b5563; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;">KV Writes Today</div>
+                      <div style="color: ${kvUsageColor}; font-size: 28px; font-weight: 700; margin-top: 4px;">${kvPutCount}</div>
+                      <div style="color: #6b7280; font-size: 12px; margin-top: 4px;">${kvPutPercent}% of ${KV_FREE_TIER_DAILY_WRITE_LIMIT} free-tier daily limit</div>
+                    </td>
+                  </tr>
+                </table>
+
                 <!-- Details Section -->
                 ${failedSection}
                 ${flagWarningSection}
@@ -1716,7 +1738,7 @@ async function checkAndSendDailySummary(env: any): Promise<void> {
 
       if (mailRes.ok) {
         console.log("Daily summary email sent successfully!");
-        await kv.put(lastSentKey, pacificDateStr);
+        await trackedKvPut(kv, lastSentKey, pacificDateStr);
         await kv.delete(logsKey);
         await kv.delete('missing_test_driver_flags');
         await kv.delete('f1_crawler_failures');

--- a/src/kv-ops.ts
+++ b/src/kv-ops.ts
@@ -1,0 +1,158 @@
+export const MAX_EDIT_FAILURES = 3;
+export const KV_DAILY_PUTS_PREFIX = 'kv_daily_puts:';
+export const PROXY_LOGS_KEY = 'proxy_daily_logs';
+
+export interface ApiLogEntry {
+  action: string;
+  method: string;
+  url: string;
+  success: boolean;
+  errorReason: string | null;
+  timestamp: string;
+}
+
+let apiLogBuffer: ApiLogEntry[] = [];
+const warningBuffers = new Map<string, string[]>();
+let invocationPutCount = 0;
+let invocationActive = false;
+
+export class EditBlockedError extends Error {
+  constructor(pageTitle: string, failures: number) {
+    super(`Edit blocked for "${pageTitle}" after ${failures} consecutive failures`);
+    this.name = 'EditBlockedError';
+  }
+}
+
+export function beginKvInvocation(): void {
+  apiLogBuffer = [];
+  warningBuffers.clear();
+  invocationPutCount = 0;
+  invocationActive = true;
+}
+
+export function getInvocationPutCount(): number {
+  return invocationPutCount;
+}
+
+export function isKvInvocationActive(): boolean {
+  return invocationActive;
+}
+
+export async function trackedKvPut(kv: any, key: string, value: string): Promise<void> {
+  if (!kv) return;
+  await kv.put(key, value);
+  invocationPutCount++;
+}
+
+async function rawKvPut(kv: any, key: string, value: string): Promise<void> {
+  if (!kv) return;
+  await kv.put(key, value);
+  invocationPutCount++;
+}
+
+export function bufferApiLog(
+  entry: Omit<ApiLogEntry, 'timestamp'> & { timestamp?: string }
+): void {
+  if (!invocationActive) return;
+  apiLogBuffer.push({
+    ...entry,
+    timestamp: entry.timestamp || new Date().toISOString(),
+  });
+}
+
+export function bufferKvWarning(key: string, message: string): void {
+  if (!invocationActive) return;
+  const existing = warningBuffers.get(key) || [];
+  existing.push(message);
+  warningBuffers.set(key, existing);
+}
+
+export function getPacificDateString(date = new Date()): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(date);
+  const year = parts.find(p => p.type === 'year')?.value;
+  const month = parts.find(p => p.type === 'month')?.value;
+  const day = parts.find(p => p.type === 'day')?.value;
+  return `${year}-${month}-${day}`;
+}
+
+export async function endKvInvocation(kv: any): Promise<void> {
+  if (!kv || !invocationActive) {
+    invocationActive = false;
+    return;
+  }
+
+  try {
+    if (apiLogBuffer.length > 0) {
+      const raw = await kv.get(PROXY_LOGS_KEY);
+      const existing = raw ? JSON.parse(raw) : [];
+      await rawKvPut(kv, PROXY_LOGS_KEY, JSON.stringify([...existing, ...apiLogBuffer]));
+    }
+
+    for (const [warnKey, messages] of warningBuffers.entries()) {
+      if (messages.length === 0) continue;
+      const raw = await kv.get(warnKey);
+      const existing: string[] = raw ? JSON.parse(raw) : [];
+      await rawKvPut(kv, warnKey, JSON.stringify([...existing, ...messages]));
+    }
+
+    if (invocationPutCount > 0) {
+      const dateStr = getPacificDateString();
+      const countKey = `${KV_DAILY_PUTS_PREFIX}${dateStr}`;
+      const raw = await kv.get(countKey);
+      const current = raw ? parseInt(raw, 10) : 0;
+      await rawKvPut(kv, countKey, String(current + invocationPutCount));
+    }
+  } finally {
+    apiLogBuffer = [];
+    warningBuffers.clear();
+    invocationPutCount = 0;
+    invocationActive = false;
+  }
+}
+
+export function editFailureKey(pageTitle: string): string {
+  return `edit_fail_count:${pageTitle.slice(0, 150)}`;
+}
+
+export async function getEditFailureCount(kv: any, pageTitle: string): Promise<number> {
+  if (!kv) return 0;
+  const raw = await kv.get(editFailureKey(pageTitle));
+  const count = raw ? parseInt(raw, 10) : 0;
+  return Number.isFinite(count) ? count : 0;
+}
+
+export async function isEditBlocked(kv: any, pageTitle: string): Promise<boolean> {
+  return (await getEditFailureCount(kv, pageTitle)) >= MAX_EDIT_FAILURES;
+}
+
+export async function recordEditFailure(kv: any, pageTitle: string): Promise<number> {
+  if (!kv) return 0;
+  const count = (await getEditFailureCount(kv, pageTitle)) + 1;
+  await trackedKvPut(kv, editFailureKey(pageTitle), String(count));
+  if (count >= MAX_EDIT_FAILURES) {
+    console.warn(`Edit blocked for "${pageTitle}" after ${count} consecutive failures`);
+  }
+  return count;
+}
+
+export async function clearEditFailures(kv: any, pageTitle: string): Promise<void> {
+  if (!kv) return;
+  await kv.delete(editFailureKey(pageTitle));
+}
+
+export async function getDailyKvPutCount(kv: any, dateStr?: string): Promise<number> {
+  if (!kv) return 0;
+  const key = `${KV_DAILY_PUTS_PREFIX}${dateStr || getPacificDateString()}`;
+  const raw = await kv.get(key);
+  const count = raw ? parseInt(raw, 10) : 0;
+  return Number.isFinite(count) ? count : 0;
+}
+
+/** Cloudflare Workers KV free-tier daily write limit (for email reporting). */
+export const KV_FREE_TIER_DAILY_WRITE_LIMIT = 1000;

--- a/src/llm-reporter.ts
+++ b/src/llm-reporter.ts
@@ -1,4 +1,5 @@
 import { PracticeSessionData } from './f1-api';
+import { bufferKvWarning } from './kv-ops';
 
 const SESSION_ARTICLE_KEYWORDS: Record<string, string[]> = {
   'FP1': ['fp1', 'free-practice-1', 'first-practice', 'practice-1', 'practice-one', 'free-practice-one'],
@@ -8,10 +9,7 @@ const SESSION_ARTICLE_KEYWORDS: Record<string, string[]> = {
 
 export async function appendKvWarning(kv: any, key: string, message: string): Promise<void> {
   if (!kv) return;
-  const raw = await kv.get(key);
-  const warnings: string[] = raw ? JSON.parse(raw) : [];
-  warnings.push(message);
-  await kv.put(key, JSON.stringify(warnings));
+  bufferKvWarning(key, message);
 }
 
 export async function logCrawlerFailure(kv: any, message: string): Promise<void> {

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -8,6 +8,7 @@ import {
   ScheduleRace,
 } from './f1-api';
 import { parsePipeParamLine } from './wikitext-parse';
+import { trackedKvPut } from './kv-ops';
 
 export const CIRCUIT_LENGTHS: Record<string, number> = {
   "albert_park": 5.278,
@@ -647,7 +648,7 @@ export async function getRoundStatsCached(
   const computed = await calculateRoundStats(year, round, trackLength, ctx);
   // Only cache if the data has confirmed race results (at least one driver with Entries > 0)
   if (env && env.F1_WIKI_STATE && Object.keys(computed).length > 0 && hasRaceResults(computed)) {
-    await env.F1_WIKI_STATE.put(kvKey, JSON.stringify(computed));
+    await trackedKvPut(env.F1_WIKI_STATE, kvKey, JSON.stringify(computed));
     console.log(`Cached stats for Round ${round} in KV (race results confirmed).`);
   } else if (Object.keys(computed).length > 0 && !hasRaceResults(computed)) {
     console.warn(`Round ${round} stats not cached: no race results yet (only qualifying/sprint data).`);
@@ -740,16 +741,12 @@ export async function get2026CumulativeStats(
       });
     });
 
-    // Save intermediate cumulative stats to avoid doing it again
-    if (env && env.F1_WIKI_STATE && r < upToRound) {
-      const intermediateKey = `2026_cumulative_stats_up_to_${r}`;
-      await env.F1_WIKI_STATE.put(intermediateKey, JSON.stringify(cumulative));
-    }
+    // Intermediate cumulative stats are kept in memory only to reduce KV writes.
   }
 
   // Save final cumulative stats to KV
   if (env && env.F1_WIKI_STATE && Object.keys(cumulative).length > 0) {
-    await env.F1_WIKI_STATE.put(targetKey, JSON.stringify(cumulative));
+    await trackedKvPut(env.F1_WIKI_STATE, targetKey, JSON.stringify(cumulative));
     console.log(`Saved cumulative stats up to Round ${upToRound} in KV.`);
   }
 

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -3,6 +3,8 @@
  * Each page/section gets its own flag so one successful sync cannot block retries for another.
  */
 
+import { trackedKvPut } from './kv-ops';
+
 export type GpPageSection =
   | 'qualifying'
   | 'grid'
@@ -103,7 +105,8 @@ export async function isKvSynced(kv: any, key: string, legacyKeys: string[] = []
 
 export async function markKvSynced(kv: any, key: string): Promise<void> {
   if (!kv) return;
-  await kv.put(key, 'true');
+  if ((await kv.get(key)) === 'true') return;
+  await trackedKvPut(kv, key, 'true');
 }
 
 export async function getGpPageSectionSyncState(

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -5,6 +5,14 @@ import {
   stripWikiComments,
   stripWikiTemplates,
 } from './wikitext-parse';
+import {
+  bufferApiLog,
+  clearEditFailures,
+  EditBlockedError,
+  isEditBlocked,
+  MAX_EDIT_FAILURES,
+  recordEditFailure,
+} from './kv-ops';
 
 export interface WikiConfig {
   domain: string; // e.g. f1.fandom.com
@@ -32,7 +40,7 @@ function getApiUrl(domain: string, apiEndpoint?: string): string {
   return `${cleanDomain}/api.php`;
 }
 
-// Helper to log wiki API calls into Cloudflare KV
+// Helper to log wiki API calls into Cloudflare KV (buffered per worker invocation)
 async function logApiCall(
   kv: any,
   action: string,
@@ -44,22 +52,15 @@ async function logApiCall(
   if (!kv) return;
 
   try {
-    const logsKey = 'proxy_daily_logs';
-    const rawLogs = await kv.get(logsKey);
-    const logs = rawLogs ? JSON.parse(rawLogs) : [];
-
-    logs.push({
+    bufferApiLog({
       action,
       method,
       url,
       success,
       errorReason: errorReason || null,
-      timestamp: new Date().toISOString()
     });
-
-    await kv.put(logsKey, JSON.stringify(logs));
   } catch (e: any) {
-    console.error("Failed to log wiki API call in KV:", e.message);
+    console.error("Failed to buffer wiki API call log:", e.message);
   }
 }
 
@@ -302,6 +303,10 @@ export async function editPage(
   summary: string,
   apiEndpoint?: string
 ): Promise<void> {
+  if (session.kvState && await isEditBlocked(session.kvState, title)) {
+    throw new EditBlockedError(title, MAX_EDIT_FAILURES);
+  }
+
   const apiUrl = getApiUrl(domain, apiEndpoint);
   const editParams = new URLSearchParams();
   editParams.append('action', 'edit');
@@ -346,6 +351,11 @@ export async function editPage(
   } finally {
     if (session.kvState) {
       await logApiCall(session.kvState, `Edit Page: ${title}`, 'POST', apiUrl, success, errorReason);
+      if (success) {
+        await clearEditFailures(session.kvState, title);
+      } else {
+        await recordEditFailure(session.kvState, title);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses excessive API call failures and KV free-tier usage reported in the daily bot summary email.

## Problem

- **650 attempted / 240 failed API calls** in one daily summary — largely from the cron worker retrying the same failing page edits every 10 minutes during race weekends.
- **>50% KV daily usage** — each proxy API log did a read-modify-write to KV (`get` + `put`), plus redundant sync flag writes and intermediate stats cache puts.

## Changes

### Edit failure limit (`src/wiki.ts`, `src/kv-ops.ts`)
- Tracks consecutive edit failures per page title in KV
- After **3 failures**, further edit attempts for that page are blocked (`EditBlockedError`) — no more proxy API calls wasted on doomed edits
- Successful edit clears the failure counter

### Reduced KV writes (`src/kv-ops.ts`)
- **Batched API logs**: buffer proxy call logs in memory during each worker invocation; flush once at end (was: 2 KV ops per API call)
- **Batched warnings**: `missing_test_driver_flags` and `f1_crawler_failures` buffered and flushed once per invocation
- **Skip redundant sync flags**: `markKvSynced` no-ops if key is already `'true'`
- **Removed intermediate cumulative stats puts** during multi-round stats builds (only final result cached)

### Daily email (`src/index.ts`)
- New **KV Writes Today** section showing count and % of free-tier daily limit (1,000 writes/day)
- Color-coded warning at 50%+ and 80%+

### Tests
- Added `scripts/verify-kv-ops.ts` covering batching, edit limits, and put counter

## Verification

```bash
npm test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb149e9b-7099-4572-8b58-eef54945edaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

