### PR TITLE
Fix practice results team name flip-flop to {{Team-Placeholder}}

### DIFF
--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -8,6 +8,7 @@ import {
   detectTestDriversFromFp1,
   findEntryListHeadingIndex,
   generatePracticeWikitext,
+  resolveDriverTeamTemplate,
 } from '../src/wikitext-generator';
 import { gpPageSectionRequired } from '../src/sync-kv';
 
@@ -124,5 +125,30 @@ const practiceWikitextNormal = generatePracticeWikitext(
 );
 assert(practiceWikitextNormal.includes('|FP2'), 'Normal weekend includes FP2 column');
 assert(practiceWikitextNormal.includes('|FP3'), 'Normal weekend includes FP3 column');
+
+// --- Team name fallback without quali results ---
+const norrisTeam = resolveDriverTeamTemplate('norris', {});
+assert(norrisTeam.includes('McLaren'), `Norris team should use roster fallback, got: ${norrisTeam}`);
+assert(!norrisTeam.includes('Team-Placeholder'), 'Roster fallback should not use placeholder');
+
+const qualiMap = { norris: '{{GBR}} {{McLaren-Mercedes}}' };
+assert(
+  resolveDriverTeamTemplate('norris', qualiMap) === qualiMap.norris,
+  'Quali map takes precedence over roster fallback'
+);
+
+const practiceWithoutQuali = generatePracticeWikitext(
+  mainDrivers as any,
+  null,
+  fp1WithTestDriver,
+  null,
+  null,
+  { hasSprint: true }
+);
+assert(
+  !practiceWithoutQuali.includes('{{Team-Placeholder}}'),
+  'Practice wikitext without quali should use roster team mapping'
+);
+assert(practiceWithoutQuali.includes('McLaren'), 'Practice table should show McLaren for Norris');
 
 console.log('verify-practice-sessions: all assertions passed');

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -684,7 +684,7 @@ The full practice results for the '''{{PAGENAME}}''' are outlined below:
         ? (getTeamEntryDetails(constructorId)?.constructor || getTeamTemplate(constructorId, entry.teamName))
         : `{{${entry.teamName}-CON}}`;
     } else {
-      team = driverToConstructorTemplate[entry.driverId] || '{{Team-Placeholder}}';
+      team = resolveDriverTeamTemplate(entry.driverId, driverToConstructorTemplate);
     }
 
     output += '\n|-';
@@ -805,6 +805,21 @@ const DRIVER_TO_CONSTRUCTOR_2026: Record<string, string> = {
   "bottas": "cadillac",
   "perez": "cadillac"
 };
+
+/** Resolve a driver's team wikitext, preferring quali data then the season roster map. */
+export function resolveDriverTeamTemplate(
+  driverId: string,
+  qualiTeamMap: Record<string, string>
+): string {
+  if (qualiTeamMap[driverId]) {
+    return qualiTeamMap[driverId];
+  }
+  const constructorId = DRIVER_TO_CONSTRUCTOR_2026[driverId];
+  if (constructorId) {
+    return getTeamTemplate(constructorId, constructorId);
+  }
+  return '{{Team-Placeholder}}';
+}
 
 export interface TeamEntryDetails {
   entrant: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The cron worker was flip-flopping team names in the Practice Results section between real constructor templates (e.g. `{{GBR}} {{McLaren-Mercedes}}`) and `{{Team-Placeholder}}` on successive runs.

## Root cause

`generatePracticeWikitext` only resolved team names from qualifying results. The cron worker fetches quali data only after quali has concluded (`needQuali = needGpPage && isQualiConcluded`), but practice sessions (FP1/FP2/FP3) can be updated earlier. On those runs `qualiResults` is empty, so every driver got `{{Team-Placeholder}}`. Once quali concluded and results were fetched, the next run wrote correct team names — causing the visible flip-flop.

## Fix

Added `resolveDriverTeamTemplate()` which falls back to the existing `DRIVER_TO_CONSTRUCTOR_2026` season roster map (already used for entry lists and test drivers) when quali data is unavailable. Quali results still take precedence when present.

## Testing

- Extended `scripts/verify-practice-sessions.ts` with assertions for roster fallback and no-placeholder practice wikitext
- `npx tsx scripts/verify-practice-sessions.ts` — all passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07793596-55c2-43bf-9566-cc2e0ac34aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07793596-55c2-43bf-9566-cc2e0ac34aeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

