### PR TITLE
fix: defer infobox KV sync until race winner fields are populated

### DIFF
--- a/scripts/verify-infobox-update.ts
+++ b/scripts/verify-infobox-update.ts
@@ -6,6 +6,7 @@ import {
   updateParameterInInfobox,
   getInfoboxParameterValue,
   isInfoboxParameterEmpty,
+  isInfoboxSyncComplete,
 } from '../src/index';
 
 const sampleInfobox = `{{Infobox_Race
@@ -52,6 +53,30 @@ assert(
 assert(
   !afterBadReplace.includes('{{Mercedes-CON}}}}'),
   'Must not leave orphan braces from partial match'
+);
+
+// 5. Sync flag should not be set when race winner is still empty
+const poleOnlyInfobox = `{{Infobox_Race
+| pole = George Russell
+| polenation = GBR
+| poleteam = {{GER}} {{Mercedes-CON}}
+| winner =
+| second =
+| third =
+}}`;
+assert(
+  !isInfoboxSyncComplete(poleOnlyInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: true }),
+  'Infobox with pole but no winner must not be considered sync-complete when race data exists'
+);
+assert(
+  !isInfoboxSyncComplete(poleOnlyInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: false }),
+  'Infobox must not be sync-complete when race results are not yet available'
+);
+
+const completeInfobox = updateParameterInInfobox(poleOnlyInfobox, 'winner', 'Max Verstappen');
+assert(
+  isInfoboxSyncComplete(completeInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: true }),
+  'Infobox with pole and winner should be sync-complete when race data exists'
 );
 
 console.log('PASS: infobox parameter read/update with template values');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1267,7 +1267,16 @@ export default {
                     }
                   }
                 }
-                await markGpPageSectionSynced('infobox');
+
+                const hasQualiData = !!(qualiResults && qualiResults.length > 0);
+                const hasSprintData = !!(race.Sprint && sprintResults && sprintResults.length > 0);
+                const hasRaceData = !!(raceResults && raceResults.length > 0);
+
+                if (isInfoboxSyncComplete(updatedContent, { hasQualiData, hasSprintData, hasRaceData })) {
+                  await markGpPageSectionSynced('infobox');
+                } else {
+                  console.log('  Infobox incomplete for available session data — will retry on next cron run.');
+                }
               }
 
               const reportSections: Array<{
@@ -1421,6 +1430,39 @@ export function getInfoboxParameterValue(infobox: string, key: string): string |
 export function isInfoboxParameterEmpty(value: string | null): boolean {
   if (value === null) return true;
   return value.trim().length === 0;
+}
+
+/** True when required infobox fields are populated for the data currently available. */
+export function isInfoboxSyncComplete(
+  wikitext: string,
+  options: {
+    hasQualiData: boolean;
+    hasSprintData: boolean;
+    hasRaceData: boolean;
+  }
+): boolean {
+  if (!options.hasRaceData) {
+    return false;
+  }
+
+  const range = findInfoboxRange(wikitext);
+  if (!range) {
+    return false;
+  }
+
+  const infobox = range.content;
+  const requiredKeys: string[] = ['winner'];
+
+  if (options.hasQualiData) {
+    requiredKeys.push('pole');
+  }
+  if (options.hasSprintData) {
+    requiredKeys.push('sprintwinner');
+  }
+
+  return requiredKeys.every(
+    (key) => !isInfoboxParameterEmpty(getInfoboxParameterValue(infobox, key))
+  );
 }
 
 export function updateParameterInInfobox(infobox: string, key: string, value: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The cron worker updated final race results on the GP page, but the infobox (winner, podium, fastest lap) was left empty.

## Root cause

The infobox section was marked as synced in KV unconditionally after any infobox update attempt. When the first post-race cron run had qualifying data but race results were not yet available from Jolpica, the worker would:

1. Populate pole position fields in the infobox
2. Mark `gp_page_infobox_synced` as `true` in KV
3. Skip winner/podium fields (no race results yet)

On the next cron run when race results became available, race results were updated but infobox updates were skipped because the KV flag was already set.

## Fix

- Add `isInfoboxSyncComplete()` to verify required infobox fields are populated before marking the section synced
- Only mark infobox synced when race results are available and `winner` is set (plus `pole` when quali data exists, `sprintwinner` on sprint weekends)
- Log a retry message when infobox remains incomplete

## Testing

- Extended `scripts/verify-infobox-update.ts` with sync-complete checks
- All existing verification scripts pass (`npm test`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12fc5c0a-b5e5-476f-9c99-3af4d206060a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12fc5c0a-b5e5-476f-9c99-3af4d206060a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

