### PR TITLE
fix: unblock infobox retry and career template false-positive sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
-    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts"
+    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-career-placeholder.ts && npx tsx scripts/verify-legacy-kv.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240320.0",

--- a/scripts/verify-career-placeholder.ts
+++ b/scripts/verify-career-placeholder.ts
@@ -1,0 +1,35 @@
+/**
+ * Verifies career results template placeholder detection.
+ * Run: npx tsx scripts/verify-career-placeholder.ts
+ */
+import { isPlaceholder } from '../src/index';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const emptyTemplate = `{{#switch:{{{1}}}
+|Max Verstappen         = 
+|George Russell         = 
+|#default = 
+}}<noinclude>[[Category:2026 Results Templates]]</noinclude>`;
+
+const austrianTemplate = `{{#switch:{{{1}}}
+|Max Verstappen         = 
+|George Russell         = 
+|Jak Crawford           = {{TD}}
+|Ayumu Iwasa            = {{TD}}
+|#default = 
+}}<noinclude>[[Category:2026 Results Templates]]</noinclude>`;
+
+const canadianTemplate = `{{#switch:{{{1}}}
+|George Russell         = {{Ret}}{{Pole}}
+|Andrea Kimi Antonelli  = {{1st|fl}}
+|#default = 
+}}<noinclude>[[Category:2026 Results Templates]]</noinclude>`;
+
+assert(isPlaceholder(emptyTemplate), 'Empty template should be placeholder');
+assert(isPlaceholder(austrianTemplate), 'TD-only template should still be placeholder');
+assert(!isPlaceholder(canadianTemplate), 'Template with race results should not be placeholder');
+
+console.log('verify-career-placeholder: all assertions passed');

--- a/scripts/verify-infobox-update.ts
+++ b/scripts/verify-infobox-update.ts
@@ -6,6 +6,7 @@ import {
   updateParameterInInfobox,
   getInfoboxParameterValue,
   isInfoboxParameterEmpty,
+  isInfoboxSyncComplete,
 } from '../src/index';
 
 const sampleInfobox = `{{Infobox_Race
@@ -52,6 +53,30 @@ assert(
 assert(
   !afterBadReplace.includes('{{Mercedes-CON}}}}'),
   'Must not leave orphan braces from partial match'
+);
+
+// 5. Sync flag should not be set when race winner is still empty
+const poleOnlyInfobox = `{{Infobox_Race
+| pole = George Russell
+| polenation = GBR
+| poleteam = {{GER}} {{Mercedes-CON}}
+| winner =
+| second =
+| third =
+}}`;
+assert(
+  !isInfoboxSyncComplete(poleOnlyInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: true }),
+  'Infobox with pole but no winner must not be considered sync-complete when race data exists'
+);
+assert(
+  !isInfoboxSyncComplete(poleOnlyInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: false }),
+  'Infobox must not be sync-complete when race results are not yet available'
+);
+
+const completeInfobox = updateParameterInInfobox(poleOnlyInfobox, 'winner', 'Max Verstappen');
+assert(
+  isInfoboxSyncComplete(completeInfobox, { hasQualiData: true, hasSprintData: false, hasRaceData: true }),
+  'Infobox with pole and winner should be sync-complete when race data exists'
 );
 
 console.log('PASS: infobox parameter read/update with template values');

--- a/scripts/verify-legacy-kv.ts
+++ b/scripts/verify-legacy-kv.ts
@@ -1,0 +1,31 @@
+/**
+ * Verifies legacy gp_updated key no longer blocks per-section infobox retries.
+ * Run: npx tsx scripts/verify-legacy-kv.ts
+ */
+import {
+  getGpPageSectionSyncState,
+  gpPageSectionKey,
+  legacyGpUpdatedKey,
+} from '../src/sync-kv';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const kv = {
+  async get(key: string): Promise<string | null> {
+    if (key === legacyGpUpdatedKey(8)) return 'true';
+    if (key === gpPageSectionKey(8, 'infobox')) return null;
+    if (key === gpPageSectionKey(8, 'race_results')) return 'true';
+    return null;
+  },
+};
+
+async function main() {
+  const state = await getGpPageSectionSyncState(kv, 8);
+  assert(state.infobox === false, 'Legacy gp_updated must not mark infobox as synced');
+  assert(state.race_results === true, 'Per-section race_results flag should still work');
+  console.log('verify-legacy-kv: all assertions passed');
+}
+
+main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1267,7 +1267,16 @@ export default {
                     }
                   }
                 }
-                await markGpPageSectionSynced('infobox');
+
+                const hasQualiData = !!(qualiResults && qualiResults.length > 0);
+                const hasSprintData = !!(race.Sprint && sprintResults && sprintResults.length > 0);
+                const hasRaceData = !!(raceResults && raceResults.length > 0);
+
+                if (isInfoboxSyncComplete(updatedContent, { hasQualiData, hasSprintData, hasRaceData })) {
+                  await markGpPageSectionSynced('infobox');
+                } else {
+                  console.log('  Infobox incomplete for available session data — will retry on next cron run.');
+                }
               }
 
               const reportSections: Array<{
@@ -1421,6 +1430,39 @@ export function getInfoboxParameterValue(infobox: string, key: string): string |
 export function isInfoboxParameterEmpty(value: string | null): boolean {
   if (value === null) return true;
   return value.trim().length === 0;
+}
+
+/** True when required infobox fields are populated for the data currently available. */
+export function isInfoboxSyncComplete(
+  wikitext: string,
+  options: {
+    hasQualiData: boolean;
+    hasSprintData: boolean;
+    hasRaceData: boolean;
+  }
+): boolean {
+  if (!options.hasRaceData) {
+    return false;
+  }
+
+  const range = findInfoboxRange(wikitext);
+  if (!range) {
+    return false;
+  }
+
+  const infobox = range.content;
+  const requiredKeys: string[] = ['winner'];
+
+  if (options.hasQualiData) {
+    requiredKeys.push('pole');
+  }
+  if (options.hasSprintData) {
+    requiredKeys.push('sprintwinner');
+  }
+
+  return requiredKeys.every(
+    (key) => !isInfoboxParameterEmpty(getInfoboxParameterValue(infobox, key))
+  );
 }
 
 export function updateParameterInInfobox(infobox: string, key: string, value: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -836,9 +836,7 @@ export default {
         }
 
         // --- 1. Smart Check for Grand Prix Career Results template ---
-        if (gpCareerTemplateSynced) {
-          console.log(`Round ${round} GP career template (${raceName}) already synced (KV cache). Skipping.`);
-        } else if (!gpSessionCompleted) {
+        if (!gpSessionCompleted) {
           console.log(`Round ${round} GP (${raceName}) not completed yet (ends: ${raceEndTime.toISOString()}). Skipping.`);
         } else if (gpResults.length > 0) {
           console.log(`Round ${round} GP has completed. Updating career results template if needed...`);
@@ -853,15 +851,28 @@ export default {
             console.error(`  Error fetching GP template: ${e.message}`);
           }
 
-          if (gpWikitext && isPlaceholder(gpWikitext)) {
-            console.log(`  GP template is a placeholder. Auto-updating results...`);
+          const expectedWikitext = generateWikiResultsText(gpResults, false);
+          if (gpWikitext.trim() === expectedWikitext.trim()) {
+            console.log(`  GP template already matches expected results.`);
+            await markKvSynced(env.F1_WIKI_STATE, gpCareerKey);
+          } else if (isPlaceholder(gpWikitext)) {
+            console.log(
+              gpCareerTemplateSynced
+                ? `  GP template KV flag set but content is still placeholder; re-syncing...`
+                : `  GP template is a placeholder. Auto-updating results...`
+            );
             const currentSession = await getSession();
-            const wikitext = generateWikiResultsText(gpResults, false);
-            await editPage(domain, currentSession, gpTitle, wikitext, "Automated results update from Jolpi API", apiEndpoint);
+            await editPage(domain, currentSession, gpTitle, expectedWikitext, "Automated results update from Jolpi API", apiEndpoint);
             console.log(`  Updated GP template for round ${round}.`);
             await markKvSynced(env.F1_WIKI_STATE, gpCareerKey);
-          } else if (gpWikitext) {
-            console.log(`  GP template already has results on Fandom.`);
+          } else if (gpCareerTemplateSynced) {
+            console.log(`  GP template KV flag set but content differs; re-syncing...`);
+            const currentSession = await getSession();
+            await editPage(domain, currentSession, gpTitle, expectedWikitext, "Automated results update from Jolpi API", apiEndpoint);
+            console.log(`  Updated GP template for round ${round}.`);
+            await markKvSynced(env.F1_WIKI_STATE, gpCareerKey);
+          } else {
+            console.log(`  GP template already has custom results on Fandom.`);
             await markKvSynced(env.F1_WIKI_STATE, gpCareerKey);
           }
         } else {
@@ -872,9 +883,7 @@ export default {
         if (race.Sprint) {
           const sprintName = raceName.replace("Grand Prix", "Sprint");
 
-          if (sprintCareerTemplateSynced) {
-            console.log(`Round ${round} Sprint career template (${sprintName}) already synced (KV cache). Skipping.`);
-          } else if (!isSprintConcluded) {
+          if (!isSprintConcluded) {
             console.log(`Round ${round} Sprint (${sprintName}) not completed yet (ends: ${sprintEndTime?.toISOString()}). Skipping.`);
           } else if (sprintResults.length > 0) {
             console.log(`Round ${round} Sprint has completed. Updating sprint template if needed...`);
@@ -889,16 +898,29 @@ export default {
               console.error(`  Error fetching Sprint template: ${e.message}`);
             }
 
-            if (sprintWikitext && isPlaceholder(sprintWikitext)) {
-              console.log(`  Sprint template is a placeholder. Auto-updating results...`);
+            const expectedSprintWikitext = generateWikiResultsText(sprintResults, true);
+            if (sprintWikitext.trim() === expectedSprintWikitext.trim()) {
+              console.log(`  Sprint template already matches expected results.`);
+              await markKvSynced(env.F1_WIKI_STATE, sprintCareerKey);
+            } else if (isPlaceholder(sprintWikitext)) {
+              console.log(
+                sprintCareerTemplateSynced
+                  ? `  Sprint template KV flag set but content is still placeholder; re-syncing...`
+                  : `  Sprint template is a placeholder. Auto-updating results...`
+              );
               const currentSession = await getSession();
-              const wikitext = generateWikiResultsText(sprintResults, true);
-              await editPage(domain, currentSession, sprintTitle, wikitext, "Automated Sprint results update from Jolpi API", apiEndpoint);
+              await editPage(domain, currentSession, sprintTitle, expectedSprintWikitext, "Automated Sprint results update from Jolpi API", apiEndpoint);
 
               await markKvSynced(env.F1_WIKI_STATE, sprintCareerKey);
               console.log(`  Marked round ${round} Sprint career template as synced in KV.`);
-            } else if (sprintWikitext) {
-              console.log(`  Sprint template already has results on Fandom.`);
+            } else if (sprintCareerTemplateSynced) {
+              console.log(`  Sprint template KV flag set but content differs; re-syncing...`);
+              const currentSession = await getSession();
+              await editPage(domain, currentSession, sprintTitle, expectedSprintWikitext, "Automated Sprint results update from Jolpi API", apiEndpoint);
+              await markKvSynced(env.F1_WIKI_STATE, sprintCareerKey);
+              console.log(`  Updated round ${round} Sprint career template.`);
+            } else {
+              console.log(`  Sprint template already has custom results on Fandom.`);
               await markKvSynced(env.F1_WIKI_STATE, sprintCareerKey);
               console.log(`  Marked round ${round} Sprint career template as synced in KV (found existing results on Fandom).`);
             }
@@ -1566,12 +1588,22 @@ function formatResult(r: any): string {
   return formatted;
 }
 
-function isPlaceholder(wikitext: string): boolean {
+function isPlaceholderResultValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed === '') return true;
+  // Test-driver placeholders should not count as published race results.
+  if (trimmed === '{{TD}}') return true;
+  return false;
+}
+
+export function isPlaceholder(wikitext: string): boolean {
   const lines = wikitext.split('\n');
   for (const line of lines) {
-    const match = line.match(/^\|([^=]+)=\s*(\S+)/);
-    if (match && match[1].trim() !== '#default' && match[2].trim() !== '') {
-      return false;
+    const match = line.match(/^\|([^=]+)=\s*(.*)/);
+    if (match && match[1].trim() !== '#default') {
+      if (!isPlaceholderResultValue(match[2])) {
+        return false;
+      }
     }
   }
   return true;

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -113,11 +113,10 @@ export async function getGpPageSectionSyncState(
   kv: any,
   round: number
 ): Promise<Record<GpPageSection, boolean>> {
-  const legacy = [legacyGpUpdatedKey(round)];
   const entries = await Promise.all(
     GP_PAGE_SECTIONS.map(async (section) => [
       section,
-      await isKvSynced(kv, gpPageSectionKey(round, section), legacy),
+      await isKvSynced(kv, gpPageSectionKey(round, section)),
     ] as const)
   );
   return Object.fromEntries(entries) as Record<GpPageSection, boolean>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Round 8 (Austrian GP) had two sync failures:
1. Infobox not updating even after deleting `2026_round_8_gp_page_infobox_synced` from KV
2. `2026_round_8_gp_career_template_synced` set to true but career template still empty

## Root causes (verified against live wiki)

### Infobox
- The legacy monolithic key `2026_round_8_gp_updated` was still treated as synced for **all** GP page sections, including infobox. Deleting the per-section infobox key had no effect while the legacy key remained.
- Live page confirms race results are populated but infobox `winner` is still empty.

### Career template
- Austrian GP template only has `{{TD}}` test-driver placeholders. `isPlaceholder()` treated `{{TD}}` as real content, so the worker logged "already has results" and set KV without editing.
- Early KV skip (`gp_career_template_synced` → skip entire block) prevented any re-check even after clearing KV.

## Fixes

1. Remove legacy `gp_updated` fallback from per-section GP page sync state
2. Treat `{{TD}}` as placeholder in career results templates
3. Always re-validate career template content against expected Jolpica output; re-sync when KV is set but content is still placeholder or differs
4. Only mark infobox KV synced when required fields are actually populated

## KV keys to clear for round 8

- `2026_round_8_gp_page_infobox_synced`
- `2026_round_8_gp_updated` (legacy — was blocking infobox retry)
- `2026_round_8_gp_career_template_synced`
- Optionally `edit_fail_count:2026 Austrian Grand Prix` if edits were blocked after prior failures

## Testing

- `scripts/verify-legacy-kv.ts` — legacy key no longer blocks infobox
- `scripts/verify-career-placeholder.ts` — Austrian TD-only template detected as placeholder
- All existing verification scripts pass (`npm test`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12fc5c0a-b5e5-476f-9c99-3af4d206060a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12fc5c0a-b5e5-476f-9c99-3af4d206060a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

