### PR TITLE
Add Jolpica API KV cache, rate limiting, and API key support

### DIFF
--- a/scripts/verify-jolpica-cache.ts
+++ b/scripts/verify-jolpica-cache.ts
@@ -1,15 +1,61 @@
 /**
- * Verifies within-run Jolpica cache deduplication and 429 backoff.
+ * Verifies Jolpica API cache: dedup, 429 backoff, KV persistence, TTL, rate limiting, API key.
  * Run: npx tsx scripts/verify-jolpica-cache.ts
  */
-import { createF1ApiContext } from '../src/f1-api-cache';
+import {
+  classifyJolpicaUrl,
+  createF1ApiContext,
+  getCacheTtl,
+  isResponseEmpty,
+} from '../src/f1-api-cache';
 import { getSchedule, getRaceResult } from '../src/f1-api';
 
+const BASE = 'https://api.jolpi.ca/ergast/f1';
+const SCHEDULE_URL = `${BASE}/2026.json?limit=1000`;
+const STANDINGS_URL = `${BASE}/2026/driverStandings.json?limit=1000`;
+
 let fetchCount = 0;
+let fetchTimestamps: number[] = [];
+let lastFetchInit: RequestInit | undefined;
 const originalFetch = globalThis.fetch;
+
+function scheduleResponse() {
+  return new Response(JSON.stringify({
+    MRData: {
+      RaceTable: {
+        Races: [{
+          season: '2026',
+          round: '1',
+          raceName: 'Test GP',
+          Circuit: { circuitId: 'test', circuitName: 'Test', Location: { locality: 'X', country: 'Y' } },
+          date: '2020-01-01',
+          time: '12:00:00Z',
+        }],
+      },
+    },
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function resultsResponse() {
+  return new Response(JSON.stringify({
+    MRData: { RaceTable: { Races: [{ Results: [{ position: '1', grid: '1' }] }] } },
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function standingsResponse(round: string) {
+  return new Response(JSON.stringify({
+    MRData: {
+      StandingsTable: {
+        StandingsLists: [{ round, DriverStandings: [{ position: '1' }] }],
+      },
+    },
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
 
 globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   fetchCount++;
+  fetchTimestamps.push(Date.now());
+  lastFetchInit = init;
   const url = String(input);
 
   if (url.includes('429-test')) {
@@ -17,23 +63,31 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   }
 
   if (url.includes('/2026.json')) {
-    return new Response(JSON.stringify({
-      MRData: {
-        RaceTable: {
-          Races: [{ season: '2026', round: '1', raceName: 'Test GP', Circuit: { circuitId: 'test', circuitName: 'Test', Location: { locality: 'X', country: 'Y' } }, date: '2026-01-01' }]
-        }
-      }
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    return scheduleResponse();
   }
 
   if (url.includes('/results.json')) {
-    return new Response(JSON.stringify({
-      MRData: { RaceTable: { Races: [{ Results: [] }] } }
-    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    return resultsResponse();
+  }
+
+  if (url.includes('/constructorStandings.json')) {
+    return standingsResponse('5');
+  }
+
+  if (url.includes('/driverStandings.json') && url.includes('stale=1')) {
+    return standingsResponse('3');
+  }
+
+  if (url.includes('/driverStandings.json')) {
+    return standingsResponse('5');
   }
 
   return originalFetch(input, init);
 };
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
 
 async function testScheduleDedup() {
   fetchCount = 0;
@@ -41,9 +95,7 @@ async function testScheduleDedup() {
   await getSchedule(2026, ctx);
   await getSchedule(2026, ctx);
   await getSchedule(2026, ctx);
-  if (fetchCount !== 1) {
-    throw new Error(`Expected 1 fetch for 3 getSchedule calls, got ${fetchCount}`);
-  }
+  assert(fetchCount === 1, `Expected 1 fetch for 3 getSchedule calls, got ${fetchCount}`);
   console.log('PASS: schedule dedup (3 calls -> 1 fetch)');
 }
 
@@ -54,9 +106,7 @@ async function testRaceResultDedup() {
     getRaceResult(2026, 1, false, ctx),
     getRaceResult(2026, 1, false, ctx),
   ]);
-  if (fetchCount !== 1) {
-    throw new Error(`Expected 1 fetch for 2 concurrent getRaceResult calls, got ${fetchCount}`);
-  }
+  assert(fetchCount === 1, `Expected 1 fetch for 2 concurrent getRaceResult calls, got ${fetchCount}`);
   console.log('PASS: race result in-flight dedup');
 }
 
@@ -64,7 +114,6 @@ async function test429Backoff() {
   fetchCount = 0;
   const ctx = createF1ApiContext();
   const start = Date.now();
-  // Temporarily override fetch for 429 scenario
   const prev = globalThis.fetch;
   let calls = 0;
   globalThis.fetch = async () => {
@@ -72,26 +121,184 @@ async function test429Backoff() {
     if (calls <= 2) {
       return new Response('throttled', { status: 429, headers: { 'Retry-After': '1' } });
     }
-    return new Response(JSON.stringify({
-      MRData: { RaceTable: { Races: [{ season: '2026', round: '1', raceName: 'Test GP', date: '2026-01-01' }] } }
-    }), { status: 200 });
+    return scheduleResponse();
   };
 
   try {
     await getSchedule(2026, ctx);
     const elapsed = Date.now() - start;
-    if (calls < 3) throw new Error(`Expected at least 3 attempts on 429, got ${calls}`);
-    if (elapsed < 1000) throw new Error(`Expected backoff delay >= 1s, got ${elapsed}ms`);
+    assert(calls >= 3, `Expected at least 3 attempts on 429, got ${calls}`);
+    assert(elapsed >= 1000, `Expected backoff delay >= 1s, got ${elapsed}ms`);
     console.log(`PASS: 429 backoff (${calls} attempts, ${elapsed}ms elapsed)`);
   } finally {
     globalThis.fetch = prev;
   }
 }
 
+function testClassifyJolpicaUrl() {
+  assert(classifyJolpicaUrl(SCHEDULE_URL) === 'schedule', 'schedule URL class');
+  assert(classifyJolpicaUrl(STANDINGS_URL) === 'seasonStandings', 'season standings URL class');
+  assert(
+    classifyJolpicaUrl(`${BASE}/2026/3/results.json?limit=1000`) === 'roundData',
+    'round data URL class'
+  );
+  console.log('PASS: classifyJolpicaUrl');
+}
+
+function testIsResponseEmpty() {
+  const emptySchedule = { MRData: { RaceTable: { Races: [] } } };
+  const fullSchedule = { MRData: { RaceTable: { Races: [{ season: '2026' }] } } };
+  assert(isResponseEmpty(SCHEDULE_URL, emptySchedule), 'empty schedule');
+  assert(!isResponseEmpty(SCHEDULE_URL, fullSchedule), 'non-empty schedule');
+  console.log('PASS: isResponseEmpty');
+}
+
+function testGetCacheTtl() {
+  const scheduleData = { MRData: { RaceTable: { Races: [{ season: '2026' }] } } };
+  assert(getCacheTtl(SCHEDULE_URL, scheduleData) === 604_800, 'schedule TTL 7 days');
+
+  const staleStandings = {
+    MRData: { StandingsTable: { StandingsLists: [{ round: '3', DriverStandings: [{}] }] } },
+  };
+  const freshStandings = {
+    MRData: { StandingsTable: { StandingsLists: [{ round: '5', DriverStandings: [{}] }] } },
+  };
+  const ctx = createF1ApiContext();
+  ctx.latestConcludedRound = 5;
+
+  assert(getCacheTtl(STANDINGS_URL, staleStandings, ctx) === 1_200, 'stale standings TTL 20m');
+  assert(getCacheTtl(STANDINGS_URL, freshStandings, ctx) === 86_400, 'fresh standings TTL 24h');
+
+  const constructorUrl = `${BASE}/2026/constructorStandings.json?limit=1000`;
+  assert(getCacheTtl(constructorUrl, freshStandings, ctx) === 86_400, 'constructor standings TTL');
+
+  console.log('PASS: getCacheTtl (schedule, stale/fresh standings)');
+}
+
+function createMockKv(store = new Map<string, string>()) {
+  const putOptions = new Map<string, { expirationTtl?: number } | undefined>();
+  return {
+    store,
+    putOptions,
+    async get(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    async put(key: string, value: string, options?: { expirationTtl?: number }) {
+      store.set(key, value);
+      putOptions.set(key, options);
+    },
+  };
+}
+
+async function testKvHit() {
+  fetchCount = 0;
+  const kv = createMockKv();
+  const cacheKey = `f1_api_cache:${SCHEDULE_URL}`;
+  kv.store.set(cacheKey, JSON.stringify({
+    MRData: {
+      RaceTable: {
+        Races: [{
+          season: '2026',
+          round: '1',
+          raceName: 'Cached GP',
+          Circuit: { circuitId: 'test', circuitName: 'Test', Location: { locality: 'X', country: 'Y' } },
+          date: '2020-01-01',
+          time: '12:00:00Z',
+        }],
+      },
+    },
+  }));
+
+  const ctx = createF1ApiContext(kv);
+  const schedule = await getSchedule(2026, ctx);
+  assert(fetchCount === 0, `KV hit should skip fetch, got ${fetchCount}`);
+  assert(schedule[0].raceName === 'Cached GP', 'Should use cached schedule data');
+  console.log('PASS: KV cache hit (0 fetches)');
+}
+
+async function testKvMissWrite() {
+  fetchCount = 0;
+  const kv = createMockKv();
+  const ctx = createF1ApiContext(kv);
+  await getSchedule(2026, ctx);
+
+  const cacheKey = `f1_api_cache:${SCHEDULE_URL}`;
+  assert(kv.store.has(cacheKey), 'Should write schedule to KV on miss');
+  assert(kv.putOptions.get(cacheKey)?.expirationTtl === 604_800, 'Schedule KV TTL should be 7 days');
+  console.log('PASS: KV cache miss write with TTL');
+}
+
+async function testRateLimitSpacing() {
+  fetchCount = 0;
+  fetchTimestamps = [];
+  const ctx = createF1ApiContext();
+  const urls = [
+    `${BASE}/2026/1/results.json?limit=1000`,
+    `${BASE}/2026/2/results.json?limit=1000`,
+    `${BASE}/2026/3/results.json?limit=1000`,
+  ];
+
+  await Promise.all(urls.map(url =>
+    import('../src/f1-api-cache').then(({ cachedJolpicaJson }) =>
+      cachedJolpicaJson(url, ctx, (data: any) => data)
+    )
+  ));
+
+  assert(fetchCount === 3, `Expected 3 fetches, got ${fetchCount}`);
+  for (let i = 1; i < fetchTimestamps.length; i++) {
+    const gap = fetchTimestamps[i] - fetchTimestamps[i - 1];
+    assert(gap >= 280, `Fetch ${i} should be >= 300ms after previous, gap=${gap}ms`);
+  }
+  console.log('PASS: rate limit spacing (>= 300ms between fetches)');
+}
+
+async function testApiKeyHeader() {
+  fetchCount = 0;
+  lastFetchInit = undefined;
+  const ctx = createF1ApiContext(undefined, 'test-api-key-secret');
+  await getSchedule(2026, ctx);
+
+  const auth = new Headers(lastFetchInit?.headers).get('Authorization');
+  assert(auth === 'Bearer test-api-key-secret', `Expected Bearer API key header, got ${auth}`);
+  console.log('PASS: API key Authorization header');
+}
+
+async function testStandingsTtlOnFetch() {
+  fetchCount = 0;
+  const kv = createMockKv();
+  const ctx = createF1ApiContext(kv);
+  ctx.latestConcludedRound = 5;
+
+  const staleUrl = `${BASE}/2026/driverStandings.json?limit=1000&stale=1`;
+  const freshUrl = `${BASE}/2026/constructorStandings.json?limit=1000`;
+
+  const { cachedJolpicaJson } = await import('../src/f1-api-cache');
+  await cachedJolpicaJson(staleUrl, ctx, (data: any) => data);
+  await cachedJolpicaJson(freshUrl, ctx, (data: any) => data);
+
+  assert(
+    kv.putOptions.get(`f1_api_cache:${staleUrl}`)?.expirationTtl === 1_200,
+    'Stale standings should get 20m KV TTL'
+  );
+  assert(
+    kv.putOptions.get(`f1_api_cache:${freshUrl}`)?.expirationTtl === 86_400,
+    'Fresh standings should get 24h KV TTL'
+  );
+  console.log('PASS: standings TTL on KV write (stale 20m, fresh 24h)');
+}
+
 async function main() {
+  testClassifyJolpicaUrl();
+  testIsResponseEmpty();
+  testGetCacheTtl();
   await testScheduleDedup();
   await testRaceResultDedup();
   await test429Backoff();
+  await testKvHit();
+  await testKvMissWrite();
+  await testRateLimitSpacing();
+  await testApiKeyHeader();
+  await testStandingsTtlOnFetch();
   console.log('All Jolpica cache verification tests passed.');
 }
 

--- a/scripts/verify-kv-ops.ts
+++ b/scripts/verify-kv-ops.ts
@@ -22,15 +22,24 @@ function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
 }
 
-function createMockKv(): { store: Map<string, string>; get: (k: string) => Promise<string | null>; put: (k: string, v: string) => Promise<void>; delete: (k: string) => Promise<void> } {
+function createMockKv(): {
+  store: Map<string, string>;
+  putOptions: Map<string, { expirationTtl?: number } | undefined>;
+  get: (k: string) => Promise<string | null>;
+  put: (k: string, v: string, options?: { expirationTtl?: number }) => Promise<void>;
+  delete: (k: string) => Promise<void>;
+} {
   const store = new Map<string, string>();
+  const putOptions = new Map<string, { expirationTtl?: number } | undefined>();
   return {
     store,
+    putOptions,
     async get(key: string) {
       return store.has(key) ? store.get(key)! : null;
     },
-    async put(key: string, value: string) {
+    async put(key: string, value: string, options?: { expirationTtl?: number }) {
       store.set(key, value);
+      putOptions.set(key, options);
     },
     async delete(key: string) {
       store.delete(key);
@@ -94,6 +103,12 @@ async function testBufferedWarnings(): Promise<void> {
   assert(crawlers.length === 1, 'Should batch crawler warnings');
 }
 
+async function testExpirationTtlPassthrough(): Promise<void> {
+  const kv = createMockKv();
+  await trackedKvPut(kv, 'ttl_key', 'val', { expirationTtl: 3600 });
+  assert(kv.putOptions.get('ttl_key')?.expirationTtl === 3600, 'Should pass expirationTtl to kv.put');
+}
+
 async function main(): Promise<void> {
   await testBufferedApiLogs();
   console.log('PASS: buffered API logs');
@@ -103,6 +118,8 @@ async function main(): Promise<void> {
   console.log('PASS: edit failure limit');
   await testBufferedWarnings();
   console.log('PASS: buffered KV warnings');
+  await testExpirationTtlPassthrough();
+  console.log('PASS: expirationTtl passthrough');
   console.log('verify-kv-ops: all assertions passed');
 }
 

--- a/src/f1-api-cache.ts
+++ b/src/f1-api-cache.ts
@@ -1,23 +1,115 @@
 /**
- * Within-run Jolpica API cache with in-flight deduplication and 429 backoff.
- * Create one context per cron invocation (or per HTTP request) and pass it through.
+ * Jolpica API cache: in-memory + KV persistence, in-flight deduplication,
+ * rate limiting, and 429 backoff. Create one context per cron invocation or HTTP request.
  */
+
+import { trackedKvPut } from './kv-ops';
 
 const MAX_RETRIES = 4;
 const BASE_BACKOFF_MS = 2000;
+const MIN_FETCH_INTERVAL_MS = 300;
+const KV_CACHE_PREFIX = 'f1_api_cache:';
+
+const TTL_SCHEDULE = 604_800;
+const TTL_STANDINGS_FRESH = 86_400;
+const TTL_STANDINGS_STALE = 1_200;
+const TTL_ROUND_DATA = 86_400;
+const TTL_DEFAULT = 1_200;
 
 export interface F1ApiContext {
   readonly cache: Map<string, unknown>;
   readonly inFlight: Map<string, Promise<unknown>>;
   apiCallCount: number;
+  kv?: any;
+  /** Optional secret: wrangler secret put JOLPICA_API_KEY */
+  apiKey?: string;
+  latestConcludedRound?: number;
+  lastFetchTime?: number;
+  fetchQueuePromise?: Promise<void>;
 }
 
-export function createF1ApiContext(): F1ApiContext {
+export function createF1ApiContext(kv?: any, apiKey?: string): F1ApiContext {
   return {
     cache: new Map(),
     inFlight: new Map(),
     apiCallCount: 0,
+    kv,
+    apiKey,
   };
+}
+
+export function createF1ApiContextFromEnv(env: {
+  F1_WIKI_STATE?: any;
+  JOLPICA_API_KEY?: string;
+}): F1ApiContext {
+  return createF1ApiContext(env.F1_WIKI_STATE, env.JOLPICA_API_KEY);
+}
+
+export type JolpicaUrlClass = 'schedule' | 'seasonStandings' | 'roundData' | 'other';
+
+export function classifyJolpicaUrl(url: string): JolpicaUrlClass {
+  const path = new URL(url).pathname;
+  if (/\/\d{4}\.json$/.test(path)) return 'schedule';
+  if (/\/\d{4}\/(driver|constructor)Standings\.json$/.test(path)) return 'seasonStandings';
+  if (/\/\d{4}\/\d+\//.test(path)) return 'roundData';
+  return 'other';
+}
+
+export function isResponseEmpty(url: string, data: unknown): boolean {
+  const mr = (data as { MRData?: Record<string, unknown> })?.MRData;
+  if (!mr) return true;
+
+  const urlClass = classifyJolpicaUrl(url);
+  if (urlClass === 'schedule') {
+    const races = (mr.RaceTable as { Races?: unknown[] } | undefined)?.Races;
+    return !races || races.length === 0;
+  }
+  if (urlClass === 'seasonStandings') {
+    const lists = (mr.StandingsTable as { StandingsLists?: unknown[] } | undefined)?.StandingsLists;
+    return !lists || lists.length === 0;
+  }
+  if (urlClass === 'roundData') {
+    const races = (mr.RaceTable as { Races?: Array<Record<string, unknown>> } | undefined)?.Races;
+    if (!races || races.length === 0) return true;
+    const race = races[0];
+    if ((race.Results as unknown[] | undefined)?.length) return false;
+    if ((race.SprintResults as unknown[] | undefined)?.length) return false;
+    if ((race.QualifyingResults as unknown[] | undefined)?.length) return false;
+    if ((race.Laps as unknown[] | undefined)?.length) return false;
+    const drivers = (mr.DriverTable as { Drivers?: unknown[] } | undefined)?.Drivers;
+    if (drivers?.length) return false;
+    return true;
+  }
+
+  const lapsRaces = (mr.LapsTable as { Races?: Array<{ Laps?: unknown[] }> } | undefined)?.Races;
+  if (lapsRaces?.length && lapsRaces[0]?.Laps?.length) return false;
+
+  return false;
+}
+
+export function getCacheTtl(url: string, data: unknown, ctx?: F1ApiContext): number {
+  if (isResponseEmpty(url, data)) {
+    return TTL_DEFAULT;
+  }
+
+  const urlClass = classifyJolpicaUrl(url);
+  if (urlClass === 'schedule') return TTL_SCHEDULE;
+  if (urlClass === 'roundData') return TTL_ROUND_DATA;
+  if (urlClass === 'seasonStandings') {
+    const lists = (data as { MRData?: { StandingsTable?: { StandingsLists?: Array<{ round?: string }> } } })
+      ?.MRData?.StandingsTable?.StandingsLists;
+    const standingsRound = lists?.[0]?.round ? parseInt(lists[0].round, 10) : 0;
+    const latestConcluded = ctx?.latestConcludedRound ?? 0;
+    if (latestConcluded > 0 && standingsRound >= latestConcluded) {
+      return TTL_STANDINGS_FRESH;
+    }
+    return TTL_STANDINGS_STALE;
+  }
+  return TTL_DEFAULT;
+}
+
+function kvCacheKey(url: string): string {
+  return `${KV_CACHE_PREFIX}${url}`;
 }
 
 function parseRetryAfterMs(retryAfter: string | null): number | null {
@@ -43,6 +135,39 @@ function backoffDelayMs(attempt: number, retryAfter: string | null): number {
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForRateLimit(ctx: F1ApiContext): Promise<void> {
+  const prev = ctx.fetchQueuePromise ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => {
+    release = resolve;
+  });
+
+  ctx.fetchQueuePromise = prev.then(async () => {
+    const now = Date.now();
+    const last = ctx.lastFetchTime ?? 0;
+    const wait = Math.max(0, MIN_FETCH_INTERVAL_MS - (now - last));
+    if (wait > 0) await sleep(wait);
+    ctx.lastFetchTime = Date.now();
+    release();
+  });
+
+  await gate;
+}
+
+function buildFetchInit(ctx?: F1ApiContext, extra?: RequestInit): RequestInit | undefined {
+  if (!ctx?.apiKey && !extra) return extra;
+  const headers = new Headers(extra?.headers);
+  if (ctx?.apiKey) {
+    headers.set('Authorization', `Bearer ${ctx.apiKey}`);
+  }
+  return { ...extra, headers };
+}
+
+async function throttledFetch(url: string, ctx: F1ApiContext, init?: RequestInit): Promise<Response> {
+  await waitForRateLimit(ctx);
+  return fetch(url, init);
 }
 
 /** Fetch from Jolpica with per-run caching, dedup, and 429 backoff. */
@@ -76,17 +201,24 @@ export async function fetchJolpica(url: string, ctx?: F1ApiContext): Promise<Res
   }
 }
 
-async function fetchJolpicaUncached(url: string, ctx?: F1ApiContext): Promise<Response> {
+async function fetchJolpicaUncached(
+  url: string,
+  ctx?: F1ApiContext,
+  init?: RequestInit
+): Promise<Response> {
   let lastError: Error | null = null;
+  const fetchInit = buildFetchInit(ctx, init);
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     if (ctx) ctx.apiCallCount++;
 
-    const res = await fetch(url);
+    const res = ctx
+      ? await throttledFetch(url, ctx, fetchInit)
+      : await fetch(url, fetchInit);
 
     if (res.status === 429) {
       const retryAfter = res.headers.get('Retry-After');
-      lastError = new Error(`Ergast API error: Too Many Requests`);
+      lastError = new Error('Jolpica API error: Too Many Requests');
       if (attempt < MAX_RETRIES) {
         const delay = backoffDelayMs(attempt, retryAfter);
         console.warn(
@@ -99,13 +231,13 @@ async function fetchJolpicaUncached(url: string, ctx?: F1ApiContext): Promise<Re
     }
 
     if (!res.ok) {
-      throw new Error(`Ergast API error: ${res.statusText}`);
+      throw new Error(`Jolpica API error: ${res.statusText}`);
     }
 
     return res;
   }
 
-  throw lastError ?? new Error('Ergast API error: Too Many Requests');
+  throw lastError ?? new Error('Jolpica API error: Too Many Requests');
 }
 
 /** Run a cached JSON fetch; deduplicates concurrent requests for the same URL. */
@@ -126,24 +258,49 @@ export async function cachedJolpicaJson<T>(
     }
   }
 
-  const promise = (async () => {
-    const res = await fetchJolpica(url, ctx);
-    const data = await res.json();
-    const parsed = parse(data);
-    if (ctx) {
-      ctx.cache.set(url, parsed);
-    }
-    return parsed;
-  })();
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
 
   if (ctx) {
     ctx.inFlight.set(url, promise);
-    try {
-      return await promise;
-    } finally {
-      ctx.inFlight.delete(url);
-    }
   }
+
+  (async () => {
+    try {
+      if (ctx?.kv) {
+        const raw = await ctx.kv.get(kvCacheKey(url));
+        if (raw) {
+          const data = JSON.parse(raw);
+          const parsed = parse(data);
+          if (ctx) ctx.cache.set(url, parsed);
+          resolve(parsed);
+          return;
+        }
+      }
+
+      const res = await fetchJolpicaUncached(url, ctx);
+      const rawText = await res.text();
+      const data = JSON.parse(rawText);
+      const parsed = parse(data);
+
+      if (ctx) {
+        ctx.cache.set(url, parsed);
+        if (ctx.kv && !isResponseEmpty(url, data)) {
+          const ttl = getCacheTtl(url, data, ctx);
+          await trackedKvPut(ctx.kv, kvCacheKey(url), rawText, { expirationTtl: ttl });
+        }
+      }
+      resolve(parsed);
+    } catch (e) {
+      reject(e);
+    } finally {
+      if (ctx) ctx.inFlight.delete(url);
+    }
+  })();
 
   return promise;
 }

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -1,6 +1,11 @@
-import { cachedJolpicaJson, createF1ApiContext, F1ApiContext } from './f1-api-cache';
+import {
+  cachedJolpicaJson,
+  createF1ApiContext,
+  createF1ApiContextFromEnv,
+  F1ApiContext,
+} from './f1-api-cache';
 
-export { createF1ApiContext, F1ApiContext };
+export { createF1ApiContext, createF1ApiContextFromEnv, F1ApiContext };
 
 export interface Driver {
   driverId: string;
@@ -145,16 +150,33 @@ function scheduleCacheKey(year: number): string {
   return `${BASE_URL}/${year}.json?limit=1000`;
 }
 
+/** Highest round whose race has ended (start + 2 hours). */
+export function getLatestConcludedRound(schedule: ScheduleRace[], now = new Date()): number {
+  let latest = 0;
+  for (const race of schedule) {
+    const start = new Date(`${race.date}T${race.time || '12:00:00Z'}`);
+    const end = new Date(start.getTime() + 2 * 60 * 60 * 1000);
+    if (now >= end) {
+      latest = Math.max(latest, parseInt(race.round, 10));
+    }
+  }
+  return latest;
+}
+
 // Fetch season schedule
 export async function getSchedule(year: number, ctx?: F1ApiContext): Promise<ScheduleRace[]> {
   const url = scheduleCacheKey(year);
-  return cachedJolpicaJson(url, ctx, (data: any) => {
+  const races = await cachedJolpicaJson(url, ctx, (data: any) => {
     const list = data.MRData.RaceTable.Races as ScheduleRace[];
     if (!list || list.length === 0) {
-      throw new Error(`Ergast API returned no races for ${year}`);
+      throw new Error(`Jolpica API returned no races for ${year}`);
     }
     return normalizeScheduleRaces(list, year);
   });
+  if (ctx) {
+    ctx.latestConcludedRound = getLatestConcludedRound(races);
+  }
+  return races;
 }
 
 export async function getScheduleWithRetry(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   fetchOfficialRaceName,
   getF1RacingKey,
   buildPracticeSessionUrl,
-  createF1ApiContext,
+  createF1ApiContextFromEnv,
   fetchRoundJolpicaData,
   F1ApiContext,
   ScheduleRace,
@@ -148,7 +148,7 @@ export default {
 
     beginKvInvocation();
     try {
-      const apiCtx = createF1ApiContext();
+      const apiCtx = createF1ApiContextFromEnv(_env);
 
       // 1. Serve SPA Frontend
       if (url.pathname === '/' || url.pathname === '/index.html') {
@@ -599,7 +599,7 @@ export default {
         return;
       }
 
-      const apiCtx = createF1ApiContext();
+      const apiCtx = createF1ApiContextFromEnv(env);
       console.log("Fetching 2026 schedule from Jolpi...");
       const year = 2026;
       const schedule = await getSchedule(year, apiCtx);

--- a/src/kv-ops.ts
+++ b/src/kv-ops.ts
@@ -38,9 +38,14 @@ export function isKvInvocationActive(): boolean {
   return invocationActive;
 }
 
-export async function trackedKvPut(kv: any, key: string, value: string): Promise<void> {
+export async function trackedKvPut(
+  kv: any,
+  key: string,
+  value: string,
+  options?: { expirationTtl?: number }
+): Promise<void> {
   if (!kv) return;
-  await kv.put(key, value);
+  await kv.put(key, value, options);
   invocationPutCount++;
 }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -561,7 +561,7 @@ export async function calculateRoundStats(
     const pts = parseFloat(r.points) || 0;
 
     roundStats[driverId].Entries = 1;
-    if (posText !== 'W') { // DNS is 'W' in Ergast
+    if (posText !== 'W') { // DNS is 'W' in Jolpica
       roundStats[driverId].Starts = 1;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds persistent Cloudflare KV caching for Jolpica F1 API responses to reduce external API calls and stay within rate limits (4 req/sec burst, 500 req/hour sustained via cache).

## Changes

- **`src/kv-ops.ts`**: `trackedKvPut` now accepts optional `{ expirationTtl }` for KV entry expiry
- **`src/f1-api-cache.ts`**: KV read/write layer (`f1_api_cache:` prefix), 300ms request serialization, optional `Authorization: Bearer` API key, exported TTL helpers (`classifyJolpicaUrl`, `isResponseEmpty`, `getCacheTtl`), and `createF1ApiContextFromEnv`
- **`src/f1-api.ts`**: `getLatestConcludedRound()` helper; `getSchedule()` sets `ctx.latestConcludedRound` after each fetch for standings TTL logic
- **`src/index.ts`**: Both HTTP and scheduled handlers use `createF1ApiContextFromEnv(env)` to pass `F1_WIKI_STATE` and `JOLPICA_API_KEY`
- **`src/stats.ts`**: Ergast → Jolpica comment rename
- **Tests**: Extended `verify-kv-ops.ts` and `verify-jolpica-cache.ts` for TTL passthrough, KV hits/misses, rate spacing, API key headers, and standings TTL

## Cache TTL rules

| Endpoint type | TTL |
|---|---|
| Season schedule | 7 days |
| Season standings (up to date) | 24 hours |
| Season standings (stale after race) | 20 minutes |
| Round-specific data | 24 hours |
| Empty responses | Skipped (no KV write) |
| Default | 20 minutes |

## Verification

```
npx tsx scripts/verify-kv-ops.ts
npx tsx scripts/verify-jolpica-cache.ts
```

Both pass.

## Deployment note

Optional API key: `wrangler secret put JOLPICA_API_KEY` (forward-looking; Jolpica token auth not yet public).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fe5123f-5d2e-47e7-aa3d-5896c2a10408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fe5123f-5d2e-47e7-aa3d-5896c2a10408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

