### PR TITLE
feat(cron): sync GP entry lists and optimize cron worker wall time

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
-    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-career-placeholder.ts && npx tsx scripts/verify-legacy-kv.ts && npx tsx scripts/verify-stats-sync.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts"
+    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-career-placeholder.ts && npx tsx scripts/verify-legacy-kv.ts && npx tsx scripts/verify-stats-sync.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts && npx tsx scripts/verify-entry-list-sync.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240320.0",

--- a/scripts/verify-entry-list-sync.ts
+++ b/scripts/verify-entry-list-sync.ts
@@ -1,0 +1,170 @@
+/**
+ * Verifies entry list syncing and PDF test driver detection.
+ * Run: npx tsx scripts/verify-entry-list-sync.ts
+ */
+import {
+  detectTestDriversFromPdf,
+  updateEntryListTableIfNeeded,
+  extractEntryListTable
+} from '../src/wikitext-generator';
+import { Driver } from '../src/f1-api';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+const mainDrivers: Driver[] = [
+  {
+    driverId: 'norris',
+    givenName: 'Lando',
+    familyName: 'Norris',
+    permanentNumber: '4',
+    nationality: 'British',
+    code: 'NOR',
+  },
+  {
+    driverId: 'piastri',
+    givenName: 'Oscar',
+    familyName: 'Piastri',
+    permanentNumber: '81',
+    nationality: 'Australian',
+    code: 'PIA',
+  }
+];
+
+// --- 1. Test PDF Detection ---
+const mockPdfText = `
+FIA FORMULA ONE WORLD CHAMPIONSHIP
+2026 Spanish Grand Prix - Entry List
+No. Driver Team
+4 Lando Norris McLaren Mastercard F1 Team
+81 Oscar Piastri McLaren Mastercard F1 Team
+34 Felipe Drugovich Aston Martin Aramco F1 Team
+`;
+
+const pdfTestDrivers = detectTestDriversFromPdf(mockPdfText, mainDrivers);
+assert(pdfTestDrivers.length === 1, `Expected 1 test driver, got ${pdfTestDrivers.length}`);
+assert(pdfTestDrivers[0].name === 'Felipe Drugovich', `Expected Felipe Drugovich, got ${pdfTestDrivers[0].name}`);
+assert(pdfTestDrivers[0].number === '34', `Expected number 34, got ${pdfTestDrivers[0].number}`);
+assert(pdfTestDrivers[0].constructorId === 'aston_martin', `Expected constructorId aston_martin, got ${pdfTestDrivers[0].constructorId}`);
+assert(pdfTestDrivers[0].flag === '{{BRA}}', `Expected flag {{BRA}}, got ${pdfTestDrivers[0].flag}`);
+
+// --- 2. Test PDF Detection Fallback ---
+const mockPdfTextWithOnlyName = `
+Some random text containing Felipe Drugovich but no number or team.
+`;
+const pdfTestDriversFallback = detectTestDriversFromPdf(mockPdfTextWithOnlyName, mainDrivers);
+assert(pdfTestDriversFallback.length === 1, `Expected 1 test driver, got ${pdfTestDriversFallback.length}`);
+assert(pdfTestDriversFallback[0].name === 'Felipe Drugovich', 'Name mismatch');
+assert(pdfTestDriversFallback[0].number === '34', 'Should fall back to default number 34');
+assert(pdfTestDriversFallback[0].constructorId === 'aston_martin', 'Should fall back to default team aston_martin');
+
+// --- 3. Test Entry List Update (New or Modified details) ---
+const existingWikiPage = `
+==Background==
+===Entry List===
+The full entry list:
+{| class="wikitable"
+!<span title="Car number">No.</span>
+!Driver
+!Entrant
+!Constructor
+!Chassis
+!Engine
+!Model
+!Tyre
+|-
+!4
+|{{GBR}} [[Lando Norris]]
+|{{GBR}} [[McLaren|Old Team Name]]
+|{{McLaren-CON}}
+|[[McLaren MCL40|MCL40]]
+|{{Mercedes-ENG}}
+|[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
+|{{Pirelli}}
+|-
+!81
+|{{AUS}} [[Oscar Piastri]]
+|{{GBR}} [[McLaren|McLaren Mastercard F1 Team]]
+|{{McLaren-CON}}
+|[[McLaren MCL40|MCL40]]
+|{{Mercedes-ENG}}
+|[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
+|{{Pirelli}}
+|-
+! colspan="8" align="center" |Source: [https://fia.com source.pdf]
+|}
+==Practice Overview==
+`;
+
+const updateResult = updateEntryListTableIfNeeded(existingWikiPage, mainDrivers, pdfTestDrivers);
+assert(updateResult.changed === true, 'Entry list table should have been updated because Norris team name differed');
+assert(updateResult.updatedWikitext.includes('McLaren Mastercard F1 Team'), 'Should have corrected Lando Norris entrant');
+assert(updateResult.updatedWikitext.includes('[[Felipe Drugovich]]'), 'Should have added Felipe Drugovich');
+assert(updateResult.updatedWikitext.includes('[[Test Driver]]s for [[#FP1|Practice 1]]'), 'Should have inserted test driver section header');
+assert(updateResult.updatedWikitext.includes('Source: [https://fia.com source.pdf]'), 'Should have preserved original source row');
+
+// Verify we don't change it if we run it again
+const runAgain = updateEntryListTableIfNeeded(updateResult.updatedWikitext, mainDrivers, pdfTestDrivers);
+assert(runAgain.changed === false, 'Running it again should detect no changes');
+
+// --- 4. Test Preserving Existing Test Drivers ---
+const wikiPageWithTestDrivers = `
+==Background==
+===Entry List===
+{| class="wikitable"
+!<span title="Car number">No.</span>
+!Driver
+!Entrant
+!Constructor
+!Chassis
+!Engine
+!Model
+!Tyre
+|-
+!4
+|{{GBR}} [[Lando Norris]]
+|{{GBR}} [[McLaren|McLaren Mastercard F1 Team]]
+|{{McLaren-CON}}
+|[[McLaren MCL40|MCL40]]
+|{{Mercedes-ENG}}
+|[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
+|{{Pirelli}}
+|-
+!81
+|{{AUS}} [[Oscar Piastri]]
+|{{GBR}} [[McLaren|McLaren Mastercard F1 Team]]
+|{{McLaren-CON}}
+|[[McLaren MCL40|MCL40]]
+|{{Mercedes-ENG}}
+|[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
+|{{Pirelli}}
+|-
+|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]
+|-
+!98
+|{{MEX}} [[Patricio O'Ward]]
+|{{GBR}} [[McLaren|McLaren Mastercard F1 Team]]
+|{{McLaren-CON}}
+|[[McLaren MCL40|MCL40]]
+|{{Mercedes-ENG}}
+|[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
+|{{Pirelli}}
+|-
+! colspan="8" align="center" |Source: [https://fia.com source.pdf]
+|}
+`;
+
+const testDrivers2 = [{
+  number: '34',
+  name: 'Felipe Drugovich',
+  flag: '{{BRA}}',
+  constructorId: 'aston_martin'
+}];
+
+const updateWithBoth = updateEntryListTableIfNeeded(wikiPageWithTestDrivers, mainDrivers, testDrivers2);
+assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich');
+assert(updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have preserved Patricio O\'Ward');
+assert(updateWithBoth.updatedWikitext.includes('Felipe Drugovich'), 'Should have added Felipe Drugovich');
+
+console.log('PASS: Entry list verification and PDF test driver detection tests.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,9 +36,10 @@ import {
   generateCareerTeamPositionWikitext,
   getNationalityCode,
   getTeamTemplate,
-  addTestDriversToEntryList,
   detectTestDriversFromFp1,
   lookupTestDriverNationality,
+  detectTestDriversFromPdf,
+  updateEntryListTableIfNeeded,
 } from './wikitext-generator';
 import { 
   loginToWiki, 
@@ -985,11 +986,46 @@ export default {
             const needFp2 = needGpPage && !race.Sprint && isFp2Concluded;
             const needFp3 = needGpPage && !race.Sprint && isFp3Concluded;
             const needPracticeScrape = needFp1 || needFp2 || needFp3;
+            const needEntryList = needDrivers && !isGpPageSectionSynced('entry_list');
 
             let fp1Results: Record<string, PracticeSessionData> | null = null;
             let fp2Results: Record<string, PracticeSessionData> | null = null;
             let fp3Results: Record<string, PracticeSessionData> | null = null;
 
+            // Fetch and parse the FIA entry list PDF if available (shared between entry list sync and practice filtering)
+            let pdfText: string | null = null;
+            if (needPracticeScrape || needEntryList) {
+              try {
+                console.log(`Fetching FIA entry list PDF for ${year} ${raceName}...`);
+                pdfText = await fetchFiaEntryListText(year, raceName);
+                if (pdfText) {
+                  console.log(`Successfully fetched and parsed FIA entry list PDF (${pdfText.length} chars).`);
+                } else {
+                  console.log(`FIA entry list PDF not found or could not be parsed.`);
+                }
+              } catch (e: any) {
+                console.error(`Error parsing FIA entry list PDF: ${e.message}`);
+              }
+            }
+
+            // --- 1. Verify and Sync Entry List ---
+            if (needEntryList && !isNewPage) {
+              if (drivers.length === 0) {
+                drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
+              }
+              const pdfTestDrivers = pdfText ? detectTestDriversFromPdf(pdfText, drivers) : [];
+              console.log(`Verifying/updating Entry List table for ${gpPageTitle}...`);
+              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, pdfTestDrivers);
+              if (entryListUpdate.changed) {
+                updatedContent = entryListUpdate.updatedWikitext;
+                changes.push("Entry List");
+              }
+              await markGpPageSectionSynced('entry_list');
+            } else if (isNewPage) {
+              await markGpPageSectionSynced('entry_list');
+            }
+
+            // --- 2. Practice Scrapes & Practice Results Section ---
             if (needPracticeScrape) {
               if (drivers.length === 0) {
                 drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
@@ -1010,20 +1046,6 @@ export default {
               fp1Results = fp1;
               fp2Results = fp2;
               fp3Results = fp3;
-
-              // Fetch and parse the FIA entry list PDF if available to filter out test drivers not participating
-              let pdfText: string | null = null;
-              try {
-                console.log(`Fetching FIA entry list PDF for ${year} ${raceName}...`);
-                pdfText = await fetchFiaEntryListText(year, raceName);
-                if (pdfText) {
-                  console.log(`Successfully fetched and parsed FIA entry list PDF (${pdfText.length} chars).`);
-                } else {
-                  console.log(`FIA entry list PDF not found or could not be parsed.`);
-                }
-              } catch (e: any) {
-                console.error(`Error parsing FIA entry list PDF: ${e.message}`);
-              }
 
               if (pdfText) {
                 const mainDriverKeys = new Set<string>();
@@ -1136,9 +1158,10 @@ export default {
                       );
                     }
                   }
-                  const withTestDrivers = addTestDriversToEntryList(updatedContent, testDrivers);
-                  if (withTestDrivers !== updatedContent) {
-                    updatedContent = withTestDrivers;
+                  console.log(`Safely merging FP1 test drivers into Entry List table for ${gpPageTitle}...`);
+                  const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, testDrivers);
+                  if (entryListUpdate.changed) {
+                    updatedContent = entryListUpdate.updatedWikitext;
                     changes.push("Entry List (Test Drivers)");
                   }
                 }
@@ -1159,6 +1182,7 @@ export default {
 
               let practicePromptContext: string | null = null;
 
+              const fpReportSectionsToGenerate = [];
               for (const sec of fpReportSections) {
                 if (!sec.required || isGpPageSectionSynced(sec.section)) continue;
                 if (!sec.results || Object.keys(sec.results).length === 0) continue;
@@ -1168,7 +1192,10 @@ export default {
                   await markGpPageSectionSynced(sec.section);
                   continue;
                 }
+                fpReportSectionsToGenerate.push(sec);
+              }
 
+              if (fpReportSectionsToGenerate.length > 0) {
                 if (!practicePromptContext) {
                   practicePromptContext = generatePromptContext(
                     race,
@@ -1181,22 +1208,32 @@ export default {
                   );
                 }
 
-                try {
-                  const reportText = await generateReportForSection(env, sec.title, practicePromptContext, {
-                    year,
-                    racingKey,
-                    sessionName: sec.sessionName,
-                  });
-                  if (reportText && reportText.length > 10) {
-                    const replaced = replaceSectionWikitext(updatedContent, sec.header, reportText);
+                console.log(`Generating ${fpReportSectionsToGenerate.length} FP reports in parallel...`);
+                const reports = await Promise.all(
+                  fpReportSectionsToGenerate.map(async (sec) => {
+                    try {
+                      const text = await generateReportForSection(env, sec.title, practicePromptContext!, {
+                        year,
+                        racingKey,
+                        sessionName: sec.sessionName,
+                      });
+                      return { sec, text };
+                    } catch (err: any) {
+                      console.error(`Failed to generate report for ${sec.title}:`, err.message);
+                      return { sec, text: null };
+                    }
+                  })
+                );
+
+                for (const { sec, text } of reports) {
+                  if (text && text.length > 10) {
+                    const replaced = replaceSectionWikitext(updatedContent, sec.header, text);
                     if (replaced !== updatedContent) {
                       updatedContent = replaced;
                       changes.push(`${sec.title} Report`);
                     }
                     await markGpPageSectionSynced(sec.section);
                   }
-                } catch (err: any) {
-                  console.error(`Failed to generate report for ${sec.title}:`, err.message);
                 }
               }
             }
@@ -1393,6 +1430,7 @@ export default {
 
               let promptContext: string | null = null;
 
+              const reportSectionsToGenerate: typeof reportSections = [];
               for (const sec of reportSections) {
                 if (!sec.check() || isGpPageSectionSynced(sec.section)) {
                   continue;
@@ -1400,39 +1438,53 @@ export default {
 
                 const sectionContent = getSectionContent(updatedContent, sec.header);
                 if (isSectionEmptyOrPlaceholder(sectionContent)) {
-                  console.log(`Section ${sec.title} is empty/placeholder. Triggering LLM writer...`);
-
-                  if (!promptContext) {
-                    const standingsData = {
-                      driverStandings: prevDrivers || [],
-                      constructorStandings: prevConstructors || []
-                    };
-                    promptContext = generatePromptContext(race, drivers, standingsData, qualiResults, sprintResults, raceResults);
-                  }
-
-                  try {
-                    let reportText = await generateReportForSection(env, sec.title, promptContext);
-                    if (reportText && reportText.length > 10) {
-                      if (sec.title === "Background") {
-                        const { weatherTemplate, tyresTemplate } = extractBackgroundTemplates(sectionContent);
-                        const weatherPart = weatherTemplate || (race.Sprint ? `{{WeatherSprint/2023\n| fp1 = \n| quali = \n| Sprint_shootout = \n| sprint = \n| race = \n}}` : `{{Weather|fp1=|fp2=|fp3=|qualification=|race=}}`);
-                        const tyresPart = tyresTemplate || `{{AvailableTyres/2023|H=|M=|S=}}`;
-                        reportText = `${weatherPart}${tyresPart}\n{{Clear}}\n${reportText}`;
-                      }
-
-                      const replaced = replaceSectionWikitext(updatedContent, sec.header, reportText);
-                      if (replaced !== updatedContent) {
-                        updatedContent = replaced;
-                        changes.push(`${sec.title} Report`);
-                      }
-                      await markGpPageSectionSynced(sec.section);
-                    }
-                  } catch (err: any) {
-                    console.error(`Failed to generate report for ${sec.title}:`, err.message);
-                  }
+                  reportSectionsToGenerate.push(sec);
                 } else {
                   console.log(`Section ${sec.title} already has custom content. Skipping to preserve human edits.`);
                   await markGpPageSectionSynced(sec.section);
+                }
+              }
+
+              if (reportSectionsToGenerate.length > 0) {
+                if (!promptContext) {
+                  const standingsData = {
+                    driverStandings: prevDrivers || [],
+                    constructorStandings: prevConstructors || []
+                  };
+                  promptContext = generatePromptContext(race, drivers, standingsData, qualiResults, sprintResults, raceResults);
+                }
+
+                console.log(`Generating ${reportSectionsToGenerate.length} session reports in parallel...`);
+                const reports = await Promise.all(
+                  reportSectionsToGenerate.map(async (sec) => {
+                    try {
+                      const text = await generateReportForSection(env, sec.title, promptContext!);
+                      return { sec, text };
+                    } catch (err: any) {
+                      console.error(`Failed to generate report for ${sec.title}:`, err.message);
+                      return { sec, text: null };
+                    }
+                  })
+                );
+
+                for (const { sec, text } of reports) {
+                  if (text && text.length > 10) {
+                    let reportText = text;
+                    if (sec.title === "Background") {
+                      const sectionContent = getSectionContent(updatedContent, sec.header);
+                      const { weatherTemplate, tyresTemplate } = extractBackgroundTemplates(sectionContent);
+                      const weatherPart = weatherTemplate || (race.Sprint ? `{{WeatherSprint/2023\n| fp1 = \n| quali = \n| Sprint_shootout = \n| sprint = \n| race = \n}}` : `{{Weather|fp1=|fp2=|fp3=|qualification=|race=}}`);
+                      const tyresPart = tyresTemplate || `{{AvailableTyres/2023|H=|M=|S=}}`;
+                      reportText = `${weatherPart}${tyresPart}\n{{Clear}}\n${reportText}`;
+                    }
+
+                    const replaced = replaceSectionWikitext(updatedContent, sec.header, reportText);
+                    if (replaced !== updatedContent) {
+                      updatedContent = replaced;
+                      changes.push(`${sec.title} Report`);
+                    }
+                    await markGpPageSectionSynced(sec.section);
+                  }
                 }
               }
             }
@@ -2103,35 +2155,45 @@ async function syncCareerStandingsTemplates(
       console.log(`Successfully updated ${pageTitle}!`);
     };
 
+    const standingsPromises: Promise<void>[] = [];
+
     // 1. Points template
     if (driverStandings.length > 0) {
-      await syncStandingsPage(
-        "Template:Career_Results/Points/2026",
-        'points',
-        generateCareerPointsWikitext(driverStandings),
-        "Automated update of driver career points template"
+      standingsPromises.push(
+        syncStandingsPage(
+          "Template:Career_Results/Points/2026",
+          'points',
+          generateCareerPointsWikitext(driverStandings),
+          "Automated update of driver career points template"
+        )
       );
     }
 
     // 2. Position template
     if (driverStandings.length > 0) {
-      await syncStandingsPage(
-        "Template:Career_Results/Position/2026",
-        'position',
-        generateCareerPositionWikitext(driverStandings),
-        "Automated update of driver career positions template"
+      standingsPromises.push(
+        syncStandingsPage(
+          "Template:Career_Results/Position/2026",
+          'position',
+          generateCareerPositionWikitext(driverStandings),
+          "Automated update of driver career positions template"
+        )
       );
     }
 
     // 3. Team Position template
     if (constructorStandings.length > 0) {
-      await syncStandingsPage(
-        "Template:Career_Results/Team_Position/2026",
-        'team_position',
-        generateCareerTeamPositionWikitext(constructorStandings),
-        "Automated update of constructor career positions template"
+      standingsPromises.push(
+        syncStandingsPage(
+          "Template:Career_Results/Team_Position/2026",
+          'team_position',
+          generateCareerTeamPositionWikitext(constructorStandings),
+          "Automated update of constructor career positions template"
+        )
       );
     }
+
+    await Promise.all(standingsPromises);
 
   } catch (e: any) {
     console.error("Failed to sync Career Results standings templates:", e.message);
@@ -2258,8 +2320,8 @@ async function syncStatsTemplates(
       return session;
     };
 
-    for (const temp of templates) {
-      await syncSingleStatsTemplate(
+    const tasks = templates.map((temp) => () =>
+      syncSingleStatsTemplate(
         env,
         domain,
         apiEndpoint,
@@ -2270,10 +2332,31 @@ async function syncStatsTemplates(
         cumulativeStats,
         raceName,
         winnerCode
-      );
-    }
+      )
+    );
+
+    await runInPool(tasks, 7);
   } catch (e: any) {
     console.error(`Scheduled stats templates sync failed: ${e.message}`);
   }
+}
+
+async function runInPool<T>(
+  tasks: (() => Promise<T>)[],
+  concurrencyLimit: number
+): Promise<T[]> {
+  const results: T[] = [];
+  let index = 0;
+  async function worker(): Promise<void> {
+    while (index < tasks.length) {
+      const currentIndex = index++;
+      results[currentIndex] = await tasks[currentIndex]();
+    }
+  }
+  const workers = Array(Math.min(concurrencyLimit, tasks.length))
+    .fill(null)
+    .map(() => worker());
+  await Promise.all(workers);
+  return results;
 }
 

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -23,7 +23,8 @@ export type GpPageSection =
   | 'practice_results_fp3'
   | 'fp1_report'
   | 'fp2_report'
-  | 'fp3_report';
+  | 'fp3_report'
+  | 'entry_list';
 
 export type CareerStandingsPage = 'points' | 'position' | 'team_position';
 
@@ -92,6 +93,7 @@ export const GP_PAGE_SECTIONS: GpPageSection[] = [
   'fp1_report',
   'fp2_report',
   'fp3_report',
+  'entry_list',
 ];
 
 export async function isKvSynced(kv: any, key: string, legacyKeys: string[] = []): Promise<boolean> {
@@ -146,6 +148,8 @@ export function gpPageSectionRequired(
     isBackgroundTime = false,
   } = options;
   switch (section) {
+    case 'entry_list':
+      return isBackgroundTime;
     case 'qualifying':
     case 'grid':
     case 'q1_report':

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -953,6 +953,7 @@ const TEAM_NAME_TO_CONSTRUCTOR: Record<string, string> = {
 
 export function teamNameToConstructorId(teamName: string): string | null {
   const key = teamName.toLowerCase().trim();
+  if (!key) return null;
   if (TEAM_NAME_TO_CONSTRUCTOR[key]) {
     return TEAM_NAME_TO_CONSTRUCTOR[key];
   }
@@ -1105,6 +1106,278 @@ export function addTestDriversToEntryList(wikitext: string, testDrivers: TestDri
   }
 
   return wikitext.slice(0, insertIndex) + rows + '\n' + wikitext.slice(insertIndex);
+}
+
+export function extractEntryListTable(wikitext: string): { start: number; end: number; content: string } | null {
+  const headingIndex = findEntryListHeadingIndex(wikitext);
+  if (headingIndex === -1) return null;
+
+  const afterHeading = wikitext.slice(headingIndex);
+  const tableStartRelative = afterHeading.indexOf('{|');
+  if (tableStartRelative === -1) return null;
+
+  const tableEndRelative = afterHeading.indexOf('|}', tableStartRelative);
+  if (tableEndRelative === -1) return null;
+
+  const start = headingIndex + tableStartRelative;
+  const end = headingIndex + tableEndRelative + 2; // include '|}'
+  return {
+    start,
+    end,
+    content: wikitext.slice(start, end)
+  };
+}
+
+const TEST_DRIVER_FALLBACKS: Record<string, { number: string; constructorId: string }> = {
+  'patricio o\'ward': { number: '98', constructorId: 'mclaren' },
+  'patricio oward': { number: '98', constructorId: 'mclaren' },
+  'felipe drugovich': { number: '34', constructorId: 'aston_martin' },
+  'isack hadjar': { number: '37', constructorId: 'red_bull' },
+  'arvid lindblad': { number: '40', constructorId: 'rb' },
+  'gabriel bortoleto': { number: '95', constructorId: 'sauber' },
+  'franco colapinto': { number: '43', constructorId: 'alpine' },
+  'andrea kimi antonelli': { number: '12', constructorId: 'mercedes' },
+  'liam lawson': { number: '40', constructorId: 'rb' },
+  'robert shwartzman': { number: '97', constructorId: 'sauber' },
+  'jack doohan': { number: '61', constructorId: 'alpine' },
+  'oliver bearman': { number: '87', constructorId: 'haas' },
+  'kush maini': { number: '61', constructorId: 'alpine' },
+};
+
+export function detectTestDriversFromPdf(
+  pdfText: string,
+  mainDrivers: Driver[]
+): TestDriverEntry[] {
+  const mainDriverKeys = new Set<string>();
+  for (const driver of mainDrivers) {
+    mainDriverKeys.add(driver.driverId.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
+    mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
+  }
+
+  const testDrivers: TestDriverEntry[] = [];
+  const normalizedPdf = pdfText.toLowerCase();
+  const lines = pdfText.split('\n');
+
+  for (const [driverName, fallback] of Object.entries(TEST_DRIVER_FALLBACKS)) {
+    const cleanName = driverName.toLowerCase().replace(/[\s'-]/g, ' ').trim();
+    const parts = cleanName.split(/\s+/);
+    const lastName = parts[parts.length - 1];
+
+    const isMain = mainDrivers.some(d => {
+      const mainName = `${d.givenName} ${d.familyName}`.toLowerCase();
+      return mainName.includes(cleanName) || cleanName.includes(mainName);
+    });
+    if (isMain) continue;
+
+    let namePresent = false;
+    if (normalizedPdf.includes(cleanName)) {
+      namePresent = true;
+    } else if (lastName.length > 2 && normalizedPdf.includes(lastName)) {
+      namePresent = true;
+    }
+
+    if (!namePresent) continue;
+
+    let detectedNumber = fallback.number;
+    let detectedConstructorId = fallback.constructorId;
+    
+    for (let i = 0; i < lines.length; i++) {
+      const lineLower = lines[i].toLowerCase();
+      if (lineLower.includes(cleanName) || (lastName.length > 2 && lineLower.includes(lastName))) {
+        const searchIndices = [i, i - 1, i + 1].filter(idx => idx >= 0 && idx < lines.length);
+
+        let foundNum = '';
+        for (const idx of searchIndices) {
+          const adjLine = lines[idx].toLowerCase();
+          const numMatch = adjLine.match(/\b\d{1,2}\b/);
+          if (numMatch) {
+            foundNum = numMatch[0];
+            break;
+          }
+        }
+        if (foundNum) {
+          detectedNumber = foundNum;
+        }
+
+        let foundConstId = '';
+        for (const idx of searchIndices) {
+          const adjLine = lines[idx].toLowerCase();
+          const matchedId = teamNameToConstructorId(adjLine);
+          if (matchedId) {
+            foundConstId = matchedId;
+            break;
+          }
+        }
+        if (foundConstId) {
+          detectedConstructorId = foundConstId;
+        }
+        break;
+      }
+    }
+
+    const nationality = lookupTestDriverNationality(driverName);
+    const flag = nationality ? getFlag(nationality) : '{{FIA}}';
+
+    testDrivers.push({
+      number: detectedNumber,
+      name: driverName.split(' ').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+      flag,
+      constructorId: detectedConstructorId,
+    });
+  }
+
+  const seen = new Set<string>();
+  const uniqueTestDrivers: TestDriverEntry[] = [];
+  for (const td of testDrivers) {
+    const cleanName = td.name.toLowerCase().replace(/[\s'-]/g, '');
+    if (!seen.has(cleanName)) {
+      seen.add(cleanName);
+      uniqueTestDrivers.push(td);
+    }
+  }
+
+  return uniqueTestDrivers.sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
+}
+
+export function updateEntryListTableIfNeeded(
+  currentWikitext: string,
+  expectedDrivers: Driver[],
+  testDrivers: TestDriverEntry[] = []
+): { updatedWikitext: string; changed: boolean } {
+  const tableInfo = extractEntryListTable(currentWikitext);
+  if (!tableInfo) {
+    return { updatedWikitext: currentWikitext, changed: false };
+  }
+
+  const parsedTestDrivers: TestDriverEntry[] = [];
+  const cleanContent = tableInfo.content.replace(/\|\}/g, '').trim();
+  const rows = cleanContent.split(/\r?\n\|-\r?\n/);
+  
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    
+    if (row.includes('colspan') || row.includes('Source') || row.includes('No.') || row.includes('Driver')) {
+      continue;
+    }
+
+    const lines = row.split('\n');
+    let number = '';
+    let name = '';
+
+    for (const line of lines) {
+      if (line.startsWith('!')) {
+        number = line.slice(1).trim();
+      } else if (line.startsWith('|')) {
+        if (!name) {
+          const linkMatch = line.match(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/);
+          if (linkMatch) {
+            name = linkMatch[1].trim();
+          }
+        }
+      }
+    }
+
+    if (number && name) {
+      const isMain = expectedDrivers.some(d => {
+        const mainName = `${d.givenName} ${d.familyName}`.toLowerCase();
+        return mainName === name.toLowerCase();
+      });
+      if (!isMain) {
+        let constructorId = '';
+        for (const line of lines) {
+          const matchedId = teamNameToConstructorId(line.toLowerCase());
+          if (matchedId) {
+            constructorId = matchedId;
+            break;
+          }
+        }
+        const nationality = lookupTestDriverNationality(name);
+        const flag = nationality ? getFlag(nationality) : '{{FIA}}';
+        parsedTestDrivers.push({
+          number,
+          name,
+          flag,
+          constructorId,
+        });
+      }
+    }
+  }
+
+  const combinedTestDriversMap = new Map<string, TestDriverEntry>();
+  parsedTestDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  testDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  const combinedTestDrivers = Array.from(combinedTestDriversMap.values())
+    .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
+
+  let entryListRows = "";
+  const sortedDrivers = [...expectedDrivers].sort((a, b) => {
+    const numA = parseInt(a.permanentNumber || '0', 10);
+    const numB = parseInt(b.permanentNumber || '0', 10);
+    return numA - numB;
+  });
+
+  for (const driver of sortedDrivers) {
+    const num = driver.permanentNumber || '';
+    const flag = getFlag(driver.nationality);
+    const name = `${driver.givenName} ${driver.familyName}`;
+    
+    const constId = DRIVER_TO_CONSTRUCTOR_2026[driver.driverId] || '';
+    const team = TEAM_DETAILS_2026[constId];
+    
+    const entrant = team ? team.entrant : '';
+    const constructor = team ? team.constructor : '';
+    const chassis = team ? team.chassis : '';
+    const engine = team ? team.engine : '';
+    const model = team ? team.model : '';
+    const tyre = team ? team.tyre : '{{Pirelli}}';
+
+    entryListRows += `\n|-\n!${num}\n|${flag} [[${name}]]\n|${entrant}\n|${constructor}\n|${chassis}\n|${engine}\n|${model}\n|${tyre}`;
+  }
+
+  if (combinedTestDrivers.length > 0) {
+    entryListRows += '\n|-\n|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
+    for (const td of combinedTestDrivers) {
+      const team = td.constructorId ? getTeamEntryDetails(td.constructorId) : null;
+      const entrant = team ? team.entrant : '';
+      const constructor = team ? team.constructor : '';
+      const chassis = team ? team.chassis : '';
+      const engine = team ? team.engine : '';
+      const model = team ? team.model : '';
+      const tyre = team ? team.tyre : '{{Pirelli}}';
+
+      entryListRows += `\n|-\n!${td.number}\n|${td.flag} [[${td.name}]]\n|${entrant}\n|${constructor}\n|${chassis}\n|${engine}\n|${model}\n|${tyre}`;
+    }
+  }
+
+  let sourceRow = `\n|-\n! colspan="8" align="center" |'''Source''': <ref name="EL">[https://www.fia.com/system/files/decision-document/{{lc:{{PAGENAMEE}}}}_-_entry_list.pdf {{PAGENAME}} - Entry List] (PDF). Fédération Internationale de l'Automobile.</ref>`;
+  for (const segment of rows) {
+    if (segment.includes('Source') || segment.includes('Source:')) {
+      sourceRow = '\n|-\n' + segment.trim();
+      break;
+    }
+  }
+
+  const newTableWikitext = `{| class="wikitable"
+!<span title="Car number">No.</span>
+!Driver
+!Entrant
+!Constructor
+!Chassis
+!Engine
+!Model
+!Tyre${entryListRows}${sourceRow}
+|}`;
+
+  if (tableInfo.content.trim() === newTableWikitext.trim()) {
+    return { updatedWikitext: currentWikitext, changed: false };
+  }
+
+  const beforeTable = currentWikitext.slice(0, tableInfo.start);
+  const afterTable = currentWikitext.slice(tableInfo.end);
+  const updatedWikitext = beforeTable + newTableWikitext + afterTable;
+
+  return { updatedWikitext, changed: true };
 }
 
 const MONTH_NAMES = [


### PR DESCRIPTION
# Walkthrough - GP Entry List Sync and Cron Wall Time Optimizations

We have successfully implemented the GP Entry List verification/sync feature, PDF-based test driver detection, and several optimizations to reduce the cron job's wall time on Cloudflare Workers.

## Changes Made

### 1. KV Sync State
- **[sync-kv.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/sync-kv.ts)**:
  - Added the `'entry_list'` page section to `GpPageSection` and `GP_PAGE_SECTIONS`.
  - Configured `gpPageSectionRequired` to require the entry list section starting from `isBackgroundTime`.

### 2. Wikitext Generation & PDF Scraping Test Driver Helpers
- **[wikitext-generator.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/wikitext-generator.ts)**:
  - Added `extractEntryListTable` to find and extract the `===Entry List===` table wikitext.
  - Added `detectTestDriversFromPdf` to check the FIA Entry List PDF text for known reserve/test drivers, resolving their details by prioritizing the driver's own text line before adjacent lines, and falling back to a default map.
  - Added `updateEntryListTableIfNeeded` to parse the existing wikitext, extract existing test drivers, merge them with new ones, and reconstruct/format the complete main and test driver entry list table cleanly.
  - Fixed a bug in `teamNameToConstructorId` where an empty key could match any constructor name due to empty substring matching.

### 3. Cron Sync Logic & Performance Optimizations
- **[index.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/index.ts)**:
  - Added an entry list verification check in the cron worker's GP page processing loop.
  - Parallelized career standings template syncs (driver points, positions, constructor positions) using `Promise.all`.
  - Parallelized stats templates updates by executing all 16-21 template sync tasks concurrently using a promise pool helper `runInPool` with a concurrency limit of **7**.
  - Parallelized LLM report generation for both practice sessions and main sessions by running API requests concurrently via `Promise.all` first, and then applying wikitext replacements sequentially.

### 4. Verification and Unit Tests
- **[package.json](file:///c:/Users/chris/Documents/GitHub/f1-fandom/package.json)**:
  - Added the new test script to `npm test`.
- **[verify-entry-list-sync.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/scripts/verify-entry-list-sync.ts)**:
  - Created unit tests verifying PDF test driver detection, fallback parsing, and entry list reconstruction/preservation logic.

---

## Validation Results

We executed the full test suite (`npm test`), and all assertions passed successfully:

```
verify-sync-kv: all assertions passed
Removing duplicate section heading: "=== Qualifying Results ==="
PASS: wikitext line-based parsing verification
All wikitext parse verification tests passed.
PASS: infobox parameter read/update with template values
All infobox verification tests passed.
verify-career-placeholder: all assertions passed
verify-legacy-kv: all assertions passed
Could not find CURRENT DRIVERS or OTHER DRIVERS markers in HatTricks. Falling back.
verify-stats-sync: all assertions passed
PASS: classifyJolpicaUrl
PASS: isResponseEmpty
PASS: getCacheTtl (schedule, stale/fresh standings)
PASS: schedule dedup (3 calls -> 1 fetch)
PASS: race result in-flight dedup
PASS: 429 backoff
PASS: KV cache hit (0 fetches)
PASS: KV cache miss write with TTL
PASS: rate limit spacing (>= 300ms between fetches)
PASS: API key Authorization header
PASS: standings TTL on KV write (stale 20m, fresh 24h)
All Jolpica cache verification tests passed.
verify-practice-sessions: all assertions passed
verify-llm-reporter: all assertions passed
verify-kv-ops: all assertions passed
PASS: Entry list verification and PDF test driver detection tests.
```
