### PR TITLE
Add STATS_SYNC env gate for cron Stats template tasks

### DIFF
--- a/scripts/verify-sync-kv.ts
+++ b/scripts/verify-sync-kv.ts
@@ -11,6 +11,7 @@ import {
   gpPageSectionRequired,
   allRequiredGpPageSectionsSynced,
   allStatsTemplatesSynced,
+  isStatsSyncEnabled,
   requiredStatsTemplateNames,
 } from '../src/sync-kv';
 
@@ -105,5 +106,10 @@ assert(allSynced, 'All GP page sections synced when every flag is true');
 
 const baseStats = requiredStatsTemplateNames({ isSprintWeekend: false, isFinalRound: false });
 assert(baseStats.length === 13, 'Base stats template count');
+
+assert(isStatsSyncEnabled({ STATS_SYNC: 'TRUE' }), 'STATS_SYNC=TRUE enables stats sync');
+assert(!isStatsSyncEnabled({}), 'Missing STATS_SYNC disables stats sync');
+assert(!isStatsSyncEnabled({ STATS_SYNC: 'true' }), 'Lowercase true does not enable stats sync');
+assert(!isStatsSyncEnabled({ STATS_SYNC: 'FALSE' }), 'STATS_SYNC=FALSE disables stats sync');
 
 console.log('verify-sync-kv: all assertions passed');

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ import {
   getGpPageSectionSyncState,
   allRequiredGpPageSectionsSynced,
   allStatsTemplatesSynced,
+  isStatsSyncEnabled,
   CareerStandingsPage,
   GpPageSection,
 } from './sync-kv';
@@ -621,6 +622,10 @@ export default {
       }
 
       const isHighFrequency = cronTrigger === "*/10 * * * *";
+      const statsSyncEnabled = isStatsSyncEnabled(env);
+      if (!statsSyncEnabled) {
+        console.log("STATS_SYNC is not set to TRUE — skipping all Stats template cron tasks.");
+      }
       
       if (isHighFrequency && !activeWeekendRace) {
         console.log("High-frequency sync skipped: No F1 race weekend is currently active.");
@@ -761,13 +766,15 @@ export default {
           ? await Promise.all([
               isKvSynced(env.F1_WIKI_STATE, gpCareerKey),
               isKvSynced(env.F1_WIKI_STATE, sprintCareerKey, [legacySprintUpdatedKey(round)]),
-              allStatsTemplatesSynced(env.F1_WIKI_STATE, round, {
-                isSprintWeekend: !!race.Sprint,
-                isFinalRound,
-              }),
+              statsSyncEnabled
+                ? allStatsTemplatesSynced(env.F1_WIKI_STATE, round, {
+                    isSprintWeekend: !!race.Sprint,
+                    isFinalRound,
+                  })
+                : Promise.resolve(true),
               getGpPageSectionSyncState(env.F1_WIKI_STATE, round),
             ])
-          : [false, false, false, {} as Record<GpPageSection, boolean>];
+          : [false, false, !statsSyncEnabled, {} as Record<GpPageSection, boolean>];
 
         const gpPageFullySynced = allRequiredGpPageSectionsSynced(gpPageSectionState, pageTiming);
 
@@ -785,7 +792,7 @@ export default {
 
         const needGpCareerTemplate = gpSessionCompleted && !gpCareerTemplateSynced;
         const needSprintTemplate = !!race.Sprint && isSprintConcluded && !sprintCareerTemplateSynced;
-        const needStats = isRaceConcluded && !statsTemplatesSynced;
+        const needStats = statsSyncEnabled && isRaceConcluded && !statsTemplatesSynced;
         const needGpPage = !gpPageFullySynced;
 
         const markGpPageSectionSynced = async (section: GpPageSection) => {
@@ -936,9 +943,7 @@ export default {
         }
 
         // --- 3. Smart Check for Stats Templates ---
-        if (!isRaceConcluded) {
-          console.log(`Round ${round} Stats Templates not completed yet. Skipping.`);
-        } else if (gpResults.length > 0) {
+        if (statsSyncEnabled && isRaceConcluded && gpResults.length > 0) {
           console.log(`GP results available. Running stats sync for round ${round}...`);
           await syncStatsTemplates(
             env,
@@ -950,6 +955,8 @@ export default {
             schedule,
             gpResults
           );
+        } else if (statsSyncEnabled && !isRaceConcluded) {
+          console.log(`Round ${round} Stats Templates not completed yet. Skipping.`);
         }
 
         // --- 4. Smart Check for GP Page Sections ---
@@ -2271,6 +2278,10 @@ async function syncStatsTemplates(
   schedule?: ScheduleRace[],
   prefetchedGpResults?: any[]
 ): Promise<void> {
+  if (!isStatsSyncEnabled(env)) {
+    return;
+  }
+
   const domain = env.DEFAULT_WIKI_DOMAIN || "f1.fandom.com";
   const apiEndpoint = env.WIKI_API_ENDPOINT;
   const proxySecret = env.PROXY_SECRET;

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -244,3 +244,8 @@ export async function allStatsTemplatesSynced(
     (await allConditionalStatsTemplatesSynced(kv, round))
   );
 }
+
+/** Stats template cron tasks run only when STATS_SYNC is exactly "TRUE". */
+export function isStatsSyncEnabled(env: { STATS_SYNC?: string }): boolean {
+  return env.STATS_SYNC === 'TRUE';
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,8 @@ preview_urls = false
 [vars]
 DEFAULT_WIKI_DOMAIN = "f1.fandom.com"
 TURNSTILE_SITE_KEY = "0x4AAAAAABoDGtBnq2BXlSqW"
+# Set to "TRUE" to enable automated Stats template sync in the cron worker.
+# STATS_SYNC = "TRUE"
 
 # Bindings (e.g. Secrets, KV) would go here if needed.
 # WIKI_BOT_USERNAME and WIKI_BOT_PASSWORD can be added via Cloudflare dashboard or `wrangler secret put`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `STATS_SYNC` environment variable gate so the cron worker only runs Stats template sync when it is explicitly enabled.

- Stats template cron tasks run only when `STATS_SYNC` is exactly `"TRUE"`.
- When disabled (unset or any other value), the worker skips Stats KV checks, avoids fetching GP results solely for stats, and does not call `syncStatsTemplates`.
- Rounds are treated as fully synced for stats purposes when the gate is off, so other sync work is not blocked.

## Changes

- Added `isStatsSyncEnabled()` helper in `src/sync-kv.ts`.
- Wired the gate into the scheduled handler in `src/index.ts` for sync eligibility, fetch planning, and the stats sync step.
- Documented the variable in `wrangler.toml`.
- Added verification assertions in `scripts/verify-sync-kv.ts`.

## Usage

Set in Cloudflare Worker vars or `wrangler.toml`:

```toml
STATS_SYNC = "TRUE"
```

If unset or set to anything other than `"TRUE"`, Stats template cron tasks are skipped.

## Testing

- `npm test` (build + all verification scripts)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a24ad63-d174-4b53-97c0-080b726d0cb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a24ad63-d174-4b53-97c0-080b726d0cb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

