### PR TITLE
fix: test driver entry list false positives, heading format, and practice phantoms

### DIFF
--- a/scripts/verify-entry-list-sync.ts
+++ b/scripts/verify-entry-list-sync.ts
@@ -66,12 +66,6 @@ const pdfTestDriversOward = detectTestDriversFromPdf(mockPdfTextOwardMentionOnly
 assert(pdfTestDriversOward.length === 0, `Expected 0 test drivers for O'Ward mention without entry row, got ${pdfTestDriversOward.length}`);
 
 // --- 3. Test Entry List Update (New or Modified details) ---
-const fp1TestDrivers = [{
-  number: '34',
-  name: 'Felipe Drugovich',
-  flag: '{{BRA}}',
-  constructorId: 'aston_martin'
-}];
 const existingWikiPage = `
 ==Background==
 ===Entry List===
@@ -109,7 +103,7 @@ The full entry list:
 ==Practice Overview==
 `;
 
-const updateResult = updateEntryListTableIfNeeded(existingWikiPage, mainDrivers, fp1TestDrivers);
+const updateResult = updateEntryListTableIfNeeded(existingWikiPage, mainDrivers, pdfTestDrivers);
 assert(updateResult.changed === true, 'Entry list table should have been updated because Norris team name differed');
 assert(updateResult.updatedWikitext.includes('McLaren Mastercard F1 Team'), 'Should have corrected Lando Norris entrant');
 assert(updateResult.updatedWikitext.includes('[[Felipe Drugovich]]'), 'Should have added Felipe Drugovich');
@@ -117,10 +111,10 @@ assert(updateResult.updatedWikitext.includes('!|colspan="8" | [[Test Driver]]s f
 assert(updateResult.updatedWikitext.includes('Source: [https://fia.com source.pdf]'), 'Should have preserved original source row');
 
 // Verify we don't change it if we run it again
-const runAgain = updateEntryListTableIfNeeded(updateResult.updatedWikitext, mainDrivers, fp1TestDrivers);
+const runAgain = updateEntryListTableIfNeeded(updateResult.updatedWikitext, mainDrivers, pdfTestDrivers);
 assert(runAgain.changed === false, 'Running it again should detect no changes');
 
-// --- 4. Test that stale wiki test drivers are removed when not in FP1 list ---
+// --- 4. Test Preserving Existing Test Drivers ---
 const wikiPageWithTestDrivers = `
 ==Background==
 ===Entry List===
@@ -175,8 +169,8 @@ const testDrivers2 = [{
 }];
 
 const updateWithBoth = updateEntryListTableIfNeeded(wikiPageWithTestDrivers, mainDrivers, testDrivers2);
-assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich and remove stale O\'Ward');
-assert(!updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have removed Patricio O\'Ward not in FP1 list');
+assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich');
+assert(updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have preserved Patricio O\'Ward');
 assert(updateWithBoth.updatedWikitext.includes('Felipe Drugovich'), 'Should have added Felipe Drugovich');
 
 console.log('PASS: Entry list verification and PDF test driver detection tests.');

--- a/scripts/verify-entry-list-sync.ts
+++ b/scripts/verify-entry-list-sync.ts
@@ -49,17 +49,29 @@ assert(pdfTestDrivers[0].number === '34', `Expected number 34, got ${pdfTestDriv
 assert(pdfTestDrivers[0].constructorId === 'aston_martin', `Expected constructorId aston_martin, got ${pdfTestDrivers[0].constructorId}`);
 assert(pdfTestDrivers[0].flag === '{{BRA}}', `Expected flag {{BRA}}, got ${pdfTestDrivers[0].flag}`);
 
-// --- 2. Test PDF Detection Fallback ---
+// --- 2. Test PDF Detection rejects name-only mentions without entry row ---
 const mockPdfTextWithOnlyName = `
 Some random text containing Felipe Drugovich but no number or team.
 `;
 const pdfTestDriversFallback = detectTestDriversFromPdf(mockPdfTextWithOnlyName, mainDrivers);
-assert(pdfTestDriversFallback.length === 1, `Expected 1 test driver, got ${pdfTestDriversFallback.length}`);
-assert(pdfTestDriversFallback[0].name === 'Felipe Drugovich', 'Name mismatch');
-assert(pdfTestDriversFallback[0].number === '34', 'Should fall back to default number 34');
-assert(pdfTestDriversFallback[0].constructorId === 'aston_martin', 'Should fall back to default team aston_martin');
+assert(pdfTestDriversFallback.length === 0, `Expected 0 test drivers without entry row, got ${pdfTestDriversFallback.length}`);
+
+// O'Ward mentioned in PDF notes but not as an entry row should not be detected
+const mockPdfTextOwardMentionOnly = `
+4 Lando Norris McLaren Mastercard F1 Team
+81 Oscar Piastri McLaren Mastercard F1 Team
+Reserve driver: Pato O'Ward (McLaren)
+`;
+const pdfTestDriversOward = detectTestDriversFromPdf(mockPdfTextOwardMentionOnly, mainDrivers);
+assert(pdfTestDriversOward.length === 0, `Expected 0 test drivers for O'Ward mention without entry row, got ${pdfTestDriversOward.length}`);
 
 // --- 3. Test Entry List Update (New or Modified details) ---
+const fp1TestDrivers = [{
+  number: '34',
+  name: 'Felipe Drugovich',
+  flag: '{{BRA}}',
+  constructorId: 'aston_martin'
+}];
 const existingWikiPage = `
 ==Background==
 ===Entry List===
@@ -97,18 +109,18 @@ The full entry list:
 ==Practice Overview==
 `;
 
-const updateResult = updateEntryListTableIfNeeded(existingWikiPage, mainDrivers, pdfTestDrivers);
+const updateResult = updateEntryListTableIfNeeded(existingWikiPage, mainDrivers, fp1TestDrivers);
 assert(updateResult.changed === true, 'Entry list table should have been updated because Norris team name differed');
 assert(updateResult.updatedWikitext.includes('McLaren Mastercard F1 Team'), 'Should have corrected Lando Norris entrant');
 assert(updateResult.updatedWikitext.includes('[[Felipe Drugovich]]'), 'Should have added Felipe Drugovich');
-assert(updateResult.updatedWikitext.includes('[[Test Driver]]s for [[#FP1|Practice 1]]'), 'Should have inserted test driver section header');
+assert(updateResult.updatedWikitext.includes('!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]'), 'Should have inserted test driver section header with ! prefix');
 assert(updateResult.updatedWikitext.includes('Source: [https://fia.com source.pdf]'), 'Should have preserved original source row');
 
 // Verify we don't change it if we run it again
-const runAgain = updateEntryListTableIfNeeded(updateResult.updatedWikitext, mainDrivers, pdfTestDrivers);
+const runAgain = updateEntryListTableIfNeeded(updateResult.updatedWikitext, mainDrivers, fp1TestDrivers);
 assert(runAgain.changed === false, 'Running it again should detect no changes');
 
-// --- 4. Test Preserving Existing Test Drivers ---
+// --- 4. Test that stale wiki test drivers are removed when not in FP1 list ---
 const wikiPageWithTestDrivers = `
 ==Background==
 ===Entry List===
@@ -140,7 +152,7 @@ const wikiPageWithTestDrivers = `
 |[[Mercedes-AMG F1 M17|F1 M17]] 1.6 [[V6]][[Turbocharger|t]]
 |{{Pirelli}}
 |-
-|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]
+!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]
 |-
 !98
 |{{MEX}} [[Patricio O'Ward]]
@@ -163,8 +175,8 @@ const testDrivers2 = [{
 }];
 
 const updateWithBoth = updateEntryListTableIfNeeded(wikiPageWithTestDrivers, mainDrivers, testDrivers2);
-assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich');
-assert(updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have preserved Patricio O\'Ward');
+assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich and remove stale O\'Ward');
+assert(!updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have removed Patricio O\'Ward not in FP1 list');
 assert(updateWithBoth.updatedWikitext.includes('Felipe Drugovich'), 'Should have added Felipe Drugovich');
 
 console.log('PASS: Entry list verification and PDF test driver detection tests.');

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -151,4 +151,26 @@ assert(
 );
 assert(practiceWithoutQuali.includes('McLaren'), 'Practice table should show McLaren for Norris');
 
+// Non-participating test drivers (no valid time/position) must not appear in practice table
+const fp1WithPhantomTestDriver = {
+  ...fp1WithTestDriver,
+  'Paul Aron': {
+    position: '',
+    number: '0',
+    driverName: 'Paul Aron',
+    teamName: '',
+    time: '',
+  },
+};
+const practiceNoPhantoms = generatePracticeWikitext(
+  mainDrivers as any,
+  null,
+  fp1WithPhantomTestDriver,
+  null,
+  null,
+  { hasSprint: true }
+);
+assert(!practiceNoPhantoms.includes('[[Paul Aron]]'), 'Should exclude test drivers without a classified session time');
+assert(practiceNoPhantoms.includes('[[Patricio O Ward]]'), 'Should still include participating test drivers');
+
 console.log('verify-practice-sessions: all assertions passed');

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -95,9 +95,9 @@ assert(findEntryListHeadingIndex(entryListPage) === 0, 'Should find ==Entry List
 assert(findEntryListHeadingIndex('== Entry List ==\ncontent') === 0, 'Should find spaced variant');
 
 const withTestDriverRows = addTestDriversToEntryList(entryListPage, testDrivers);
-assert(withTestDriverRows.includes('[[Test Driver]]s for [[#FP1|Practice 1]]'), 'Test driver header row');
+assert(withTestDriverRows.includes('!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]'), 'Test driver header row with ! prefix');
 assert(withTestDriverRows.includes('[[Patricio O Ward]]'), 'Test driver name in entry list');
-assert(withTestDriverRows.indexOf('[[Test Driver]]') < withTestDriverRows.indexOf("'''Source'''"), 'Inserted before source row');
+assert(withTestDriverRows.indexOf('!|colspan="8"') < withTestDriverRows.indexOf("'''Source'''"), 'Inserted before source row');
 
 const unchanged = addTestDriversToEntryList(withTestDriverRows, testDrivers);
 assert(unchanged === withTestDriverRows, 'Should not duplicate existing test drivers');

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import {
   getTeamTemplate,
   detectTestDriversFromFp1,
   lookupTestDriverNationality,
+  detectTestDriversFromPdf,
   updateEntryListTableIfNeeded,
 } from './wikitext-generator';
 import { 
@@ -1018,8 +1019,9 @@ export default {
               if (drivers.length === 0) {
                 drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
               }
+              const pdfTestDrivers = pdfText ? detectTestDriversFromPdf(pdfText, drivers) : [];
               console.log(`Verifying/updating Entry List table for ${gpPageTitle}...`);
-              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, []);
+              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, pdfTestDrivers);
               if (entryListUpdate.changed) {
                 updatedContent = entryListUpdate.updatedWikitext;
                 changes.push("Entry List");

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,6 @@ import {
   getTeamTemplate,
   detectTestDriversFromFp1,
   lookupTestDriverNationality,
-  detectTestDriversFromPdf,
   updateEntryListTableIfNeeded,
 } from './wikitext-generator';
 import { 
@@ -1019,9 +1018,8 @@ export default {
               if (drivers.length === 0) {
                 drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
               }
-              const pdfTestDrivers = pdfText ? detectTestDriversFromPdf(pdfText, drivers) : [];
               console.log(`Verifying/updating Entry List table for ${gpPageTitle}...`);
-              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, pdfTestDrivers);
+              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, []);
               if (entryListUpdate.changed) {
                 updatedContent = entryListUpdate.updatedWikitext;
                 changes.push("Entry List");

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -585,6 +585,9 @@ export function generatePracticeWikitext(
     const testDrivers: PracticeSessionData[] = [];
     for (const data of Object.values(sessionData)) {
       if (isMainDriver(data.driverName)) continue;
+      const pos = data.position?.trim() ?? '';
+      const time = data.time?.trim() ?? '';
+      if (!/^\d+$/.test(pos) || !time || time === 'No Time') continue;
       const key = data.driverName.toLowerCase().replace(/[\s'-]/g, '');
       if (seen.has(key)) continue;
       seen.add(key);
@@ -602,7 +605,9 @@ export function generatePracticeWikitext(
     return arr.findIndex(x => x.driverName.toLowerCase().replace(/[\s'-]/g, '') === key) === idx;
   });
 
-  const tableDrivers: Array<Driver | PracticeSessionData> = [...drivers];
+  const rosterDrivers = drivers.filter(d => DRIVER_TO_CONSTRUCTOR_2026[d.driverId]);
+
+  const tableDrivers: Array<Driver | PracticeSessionData> = [...rosterDrivers];
   for (const td of testDriverRows) {
     tableDrivers.push(td);
   }
@@ -1259,13 +1264,65 @@ export function updateEntryListTableIfNeeded(
     return { updatedWikitext: currentWikitext, changed: false };
   }
 
-  // Test drivers are authoritative from FP1 participation only — do not preserve
-  // stale wiki rows that may have been added by overly broad PDF name matching.
-  const combinedTestDrivers = [...testDrivers]
-    .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
-
+  const parsedTestDrivers: TestDriverEntry[] = [];
   const cleanContent = tableInfo.content.replace(/\|\}/g, '').trim();
   const rows = cleanContent.split(/\r?\n\|-\r?\n/);
+  
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    
+    if (row.includes('colspan') || row.includes('Source') || row.includes('No.') || row.includes('Driver')) {
+      continue;
+    }
+
+    const lines = row.split('\n');
+    let number = '';
+    let name = '';
+
+    for (const line of lines) {
+      if (line.startsWith('!')) {
+        number = line.slice(1).trim();
+      } else if (line.startsWith('|')) {
+        if (!name) {
+          const linkMatch = line.match(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/);
+          if (linkMatch) {
+            name = linkMatch[1].trim();
+          }
+        }
+      }
+    }
+
+    if (number && name) {
+      const isMain = expectedDrivers.some(d => {
+        const mainName = `${d.givenName} ${d.familyName}`.toLowerCase();
+        return mainName === name.toLowerCase();
+      });
+      if (!isMain) {
+        let constructorId = '';
+        for (const line of lines) {
+          const matchedId = teamNameToConstructorId(line.toLowerCase());
+          if (matchedId) {
+            constructorId = matchedId;
+            break;
+          }
+        }
+        const nationality = lookupTestDriverNationality(name);
+        const flag = nationality ? getFlag(nationality) : '{{FIA}}';
+        parsedTestDrivers.push({
+          number,
+          name,
+          flag,
+          constructorId,
+        });
+      }
+    }
+  }
+
+  const combinedTestDriversMap = new Map<string, TestDriverEntry>();
+  parsedTestDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  testDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  const combinedTestDrivers = Array.from(combinedTestDriversMap.values())
+    .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
 
   let entryListRows = "";
   const sortedDrivers = [...expectedDrivers].sort((a, b) => {

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -1092,7 +1092,7 @@ export function addTestDriversToEntryList(wikitext: string, testDrivers: TestDri
     insertIndex = headingIndex + closeIdx;
   }
 
-  let rows = '\n|-\n|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
+  let rows = '\n|-\n!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
   for (const td of newDrivers) {
     const team = td.constructorId ? getTeamEntryDetails(td.constructorId) : null;
     const entrant = team ? team.entrant : '';
@@ -1170,14 +1170,23 @@ export function detectTestDriversFromPdf(
     });
     if (isMain) continue;
 
-    let namePresent = false;
-    if (normalizedPdf.includes(cleanName)) {
-      namePresent = true;
-    } else if (lastName.length > 2 && normalizedPdf.includes(lastName)) {
-      namePresent = true;
-    }
+    if (!normalizedPdf.includes(cleanName)) continue;
 
-    if (!namePresent) continue;
+    // Require the driver to appear on an entry-list row (name + car number on same/adjacent line)
+    let hasEntryRow = false;
+    for (let i = 0; i < lines.length; i++) {
+      const lineLower = lines[i].toLowerCase();
+      if (!lineLower.includes(cleanName)) continue;
+      const searchIndices = [i, i - 1, i + 1].filter(idx => idx >= 0 && idx < lines.length);
+      for (const idx of searchIndices) {
+        if (/\b\d{1,2}\b/.test(lines[idx])) {
+          hasEntryRow = true;
+          break;
+        }
+      }
+      if (hasEntryRow) break;
+    }
+    if (!hasEntryRow) continue;
 
     let detectedNumber = fallback.number;
     let detectedConstructorId = fallback.constructorId;
@@ -1250,65 +1259,13 @@ export function updateEntryListTableIfNeeded(
     return { updatedWikitext: currentWikitext, changed: false };
   }
 
-  const parsedTestDrivers: TestDriverEntry[] = [];
+  // Test drivers are authoritative from FP1 participation only — do not preserve
+  // stale wiki rows that may have been added by overly broad PDF name matching.
+  const combinedTestDrivers = [...testDrivers]
+    .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
+
   const cleanContent = tableInfo.content.replace(/\|\}/g, '').trim();
   const rows = cleanContent.split(/\r?\n\|-\r?\n/);
-  
-  for (let i = 1; i < rows.length; i++) {
-    const row = rows[i];
-    
-    if (row.includes('colspan') || row.includes('Source') || row.includes('No.') || row.includes('Driver')) {
-      continue;
-    }
-
-    const lines = row.split('\n');
-    let number = '';
-    let name = '';
-
-    for (const line of lines) {
-      if (line.startsWith('!')) {
-        number = line.slice(1).trim();
-      } else if (line.startsWith('|')) {
-        if (!name) {
-          const linkMatch = line.match(/\[\[([^\]|]+)(?:\|[^\]]*)?\]\]/);
-          if (linkMatch) {
-            name = linkMatch[1].trim();
-          }
-        }
-      }
-    }
-
-    if (number && name) {
-      const isMain = expectedDrivers.some(d => {
-        const mainName = `${d.givenName} ${d.familyName}`.toLowerCase();
-        return mainName === name.toLowerCase();
-      });
-      if (!isMain) {
-        let constructorId = '';
-        for (const line of lines) {
-          const matchedId = teamNameToConstructorId(line.toLowerCase());
-          if (matchedId) {
-            constructorId = matchedId;
-            break;
-          }
-        }
-        const nationality = lookupTestDriverNationality(name);
-        const flag = nationality ? getFlag(nationality) : '{{FIA}}';
-        parsedTestDrivers.push({
-          number,
-          name,
-          flag,
-          constructorId,
-        });
-      }
-    }
-  }
-
-  const combinedTestDriversMap = new Map<string, TestDriverEntry>();
-  parsedTestDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
-  testDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
-  const combinedTestDrivers = Array.from(combinedTestDriversMap.values())
-    .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
 
   let entryListRows = "";
   const sortedDrivers = [...expectedDrivers].sort((a, b) => {
@@ -1336,7 +1293,7 @@ export function updateEntryListTableIfNeeded(
   }
 
   if (combinedTestDrivers.length > 0) {
-    entryListRows += '\n|-\n|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
+    entryListRows += '\n|-\n!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]';
     for (const td of combinedTestDrivers) {
       const team = td.constructorId ? getTeamEntryDetails(td.constructorId) : null;
       const entrant = team ? team.entrant : '';


### PR DESCRIPTION
## Summary

Fixes test driver bugs on GP page Entry List and Practice Results tables for the 2026 British Grand Prix and similar weekends.

### Entry List

- **False positive test drivers (e.g. Pato O'Ward)** — `detectTestDriversFromPdf` previously matched reserve-driver mentions via last-name-only PDF scanning. Detection now requires the full driver name on an entry-list row with a car number on the same or adjacent line.
- **Pre-FP1 entry list sync preserved** — Test drivers continue to be detected from the FIA PDF during entry list sync (before FP1), merged with existing wiki rows and FP1 additions. FP1 is not the sole authoritative source.
- **Heading format** — Test driver section header now uses correct MediaWiki syntax: `!|colspan="8" | [[Test Driver]]s for [[#FP1|Practice 1]]`

### Practice Results

- **Phantom DNP rows** — Non-participating drivers (e.g. Paul Aron, Dino Beganovic, Luke Browning, Jak Crawford, Ryo Hirakawa, Ayumu Iwasa) were appearing with `No. 0`, `{{Team-Placeholder}}`, and DNP. Practice table generation now:
  - Only includes test drivers with a classified session time and position
  - Limits main-driver rows to the known 2026 roster map (`DRIVER_TO_CONSTRUCTOR_2026`)

### Wiki history context (2026 British GP)

| Revision | Time (UTC) | Trigger | Change |
|----------|------------|---------|--------|
| 152439 | 06:01 | Hourly cron | Entry List — O'Ward added (PDF false positive) |
| 152440 | 07:01 | Hourly cron | Practice Results — 6 phantom drivers added |
| 152441 | 07:21 | 21-min cron | Practice Results — phantoms removed (clean re-scrape overwrote bad table) |

The hourly and 21-minute crons share the same GP-page practice logic; the 21-min run did not intentionally fix anything — it re-ran the same path ~20 minutes later with clean scrape data. Both crons currently rewrite practice results every run (no skip-on-sync guard), which caused the apparent hourly-break / 21-min-fix pattern.

## Verification

- `npx tsx scripts/verify-entry-list-sync.ts`
- `npx tsx scripts/verify-practice-sessions.ts`

Both pass, including regression tests for O'Ward mention-only PDF text and phantom test driver exclusion from practice tables.