### PR TITLE
feat: implement OpenF1 integration for Sprint Qualifying cron sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A comprehensive automation tool for generating and maintaining Formula One Wiki 
 - **Latest News & Events Sync**: Periodically compiles the previous, latest, and upcoming event schedules and updates `Template:Latest_F1_News/Events`.
 - **Career Standing Templates Sync**: Automatically keeps the F1 Fandom career standing templates (`Template:Career_Results/Points/2026`, `Template:Career_Results/Position/2026`, and `Template:Career_Results/Team_Position/2026`) synchronized with the latest standings from the Jolpi API.
 - **Concluded Sessions Polling**: Automatically checks KV caches and conclusion status for completed Grand Prix and Sprint sessions, polling results and deploying them to wiki templates as soon as they become available.
+- **Sprint Qualifying Automation**: Fetches Sprint Qualifying session classifications from the OpenF1 API, resolves driver numbers to current season constructors, and updates the GP page's Sprint Qualifying Results section with a formatted wikitext table.
 - **Practice Session Automation**: Scrapes F1.com practice results (FP1, FP2, FP3) during active race weekends, updates the GP page practice results table incrementally, and retries automatically when results are not yet published.
 - **Entry List Synchronization & Test Drivers**: Automatically updates and maintains the Grand Prix page's main Entry List table using FIA Entry List PDF data, detects rookie/test drivers appearing in FP1, validates them against the PDF, and appends them to a dedicated "Test Drivers for Practice 1" subsection with team details from `TEAM_DETAILS_2026`.
 - **Scheduled Stats Sync**: Automatically computes and synchronizes career stats templates once a race weekend's Grand Prix results are published.
@@ -96,9 +97,10 @@ f1-fandom/
 │   ├── verify-infobox-update.ts    # Infobox parameter read/update tests
 │   ├── verify-jolpica-cache.ts     # API cache dedup and backoff tests
 │   ├── verify-practice-sessions.ts # Practice scraping and test driver tests
+│   ├── verify-openf1-sync.ts       # OpenF1 Sprint Qualifying sync and wikitext tests
 │   ├── verify-llm-reporter.ts      # HTML sanitization and prompt context tests
 │   ├── verify-entry-list-sync.ts   # Entry list table sync and PDF parser tests
-│   ├── verify-kv-ops.ts            # KV daily write count and edit failure block tests
+│   ├── verify-kv-ops.ts            # KV daily write count and edit failure lock tests
 │   └── verify-stats-sync.ts        # Career stats template calculations verification
 ├── f1.py                     # Python wiki table generator
 ├── pyergast.py               # Python Ergast API wrapper
@@ -124,6 +126,12 @@ This runs the TypeScript compiler (`tsc --noEmit`) and all verification scripts 
 ## Recent Updates & Changelog
 
 Summary of improvements (updated July 4, 2026):
+
+### OpenF1 Sprint Qualifying Cron Update (July 2026)
+- **OpenF1 API Integration**: Integrated `api.openf1.org` to retrieve Sprint Qualifying classifications.
+- **Sprint Qualifying Table Generation**: Added `generateSprintQualifyingWikitext` to compile results into a structured wikitext table with SQ1/SQ2/SQ3 segment classification times, 107% time calculations, and official FIA source reference.
+- **Standings-Based Constructor Mapping**: Maps driver numbers to constructors dynamically using active standings or fallback Jolpica constructor endpoint queries.
+- **Unit and Integration Tests**: Added a dedicated `verify-openf1-sync.ts` test suite to the project test runner to verify time formatting and wikitext table compilation.
 
 ### Entry List Syncing & Team Details (July 2026)
 - **Automated Entry List Syncing**: Cron worker automatically updates and maintains Grand Prix Entry List tables, detecting rookie/test drivers in FP1 results, validating them against the FIA Entry List PDF, and appending them to the "Test Drivers for Practice 1" subsection.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "tsc --noEmit",
-    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-career-placeholder.ts && npx tsx scripts/verify-legacy-kv.ts && npx tsx scripts/verify-stats-sync.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts && npx tsx scripts/verify-entry-list-sync.ts"
+    "test": "npm run build && npx tsx scripts/verify-sync-kv.ts && npx tsx scripts/verify-wikitext-parse.ts && npx tsx scripts/verify-infobox-update.ts && npx tsx scripts/verify-career-placeholder.ts && npx tsx scripts/verify-legacy-kv.ts && npx tsx scripts/verify-stats-sync.ts && npx tsx scripts/verify-jolpica-cache.ts && npx tsx scripts/verify-practice-sessions.ts && npx tsx scripts/verify-llm-reporter.ts && npx tsx scripts/verify-kv-ops.ts && npx tsx scripts/verify-entry-list-sync.ts && npx tsx scripts/verify-openf1-sync.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240320.0",

--- a/scripts/verify-openf1-sync.ts
+++ b/scripts/verify-openf1-sync.ts
@@ -1,72 +1,207 @@
-import { formatOpenF1Time, getOpenF1SprintQualifyingResult } from '../src/f1-api';
+import {
+  createF1ApiContext,
+  fetchOpenF1Json,
+  fetchRoundJolpicaData,
+  formatOpenF1SessionSegmentTime,
+  formatOpenF1Time,
+  getDriverStandings,
+  getOpenF1SprintQualifyingResult,
+  matchOpenF1SprintQualifyingSession,
+  OpenF1Session,
+} from '../src/f1-api';
 import { generateSprintQualifyingWikitext } from '../src/wikitext-generator';
 
 function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(message);
 }
 
-// 1. Test formatOpenF1Time
-console.log("Testing formatOpenF1Time...");
-assert(formatOpenF1Time(89.273) === '1:29.273', 'Hamilton pole time format');
-assert(formatOpenF1Time(9.005) === '09.005', 'Single digit seconds format');
-assert(formatOpenF1Time(0) === '00.000', 'Zero seconds format');
-assert(formatOpenF1Time(null) === '', 'Null format');
-assert(formatOpenF1Time(undefined) === '', 'Undefined format');
+async function main(): Promise<void> {
+  // 1. Test formatOpenF1Time
+  console.log('Testing formatOpenF1Time...');
+  assert(formatOpenF1Time(89.273) === '1:29.273', 'Hamilton pole time format');
+  assert(formatOpenF1Time(9.005) === '09.005', 'Single digit seconds format');
+  assert(formatOpenF1Time(0) === '00.000', 'Zero seconds format');
+  assert(formatOpenF1Time(null) === '', 'Null format');
+  assert(formatOpenF1Time(undefined) === '', 'Undefined format');
 
-// 2. Test generateSprintQualifyingWikitext
-console.log("Testing generateSprintQualifyingWikitext...");
-const mockDrivers = [
-  {
-    driverId: 'hamilton',
-    givenName: 'Lewis',
-    familyName: 'Hamilton',
-    permanentNumber: '44',
-    nationality: 'British',
-    code: 'HAM',
-    dateOfBirth: '',
-    url: ''
-  },
-  {
-    driverId: 'russell',
-    givenName: 'George',
-    familyName: 'Russell',
-    permanentNumber: '63',
-    nationality: 'British',
-    code: 'RUS',
-    dateOfBirth: '',
-    url: ''
-  }
-];
+  // 2. Test DNS/DSQ segment formatting
+  console.log('Testing formatOpenF1SessionSegmentTime...');
+  assert(
+    formatOpenF1SessionSegmentTime(null, { dns: true, dnf: false, dsq: false }, 0) === 'DNS',
+    'DNS in SQ1'
+  );
+  assert(
+    formatOpenF1SessionSegmentTime(null, { dns: true, dnf: false, dsq: false }, 1) === '',
+    'DNS leaves later segments blank'
+  );
+  assert(
+    formatOpenF1SessionSegmentTime(87.5, { dns: false, dnf: false, dsq: true }, 0) === 'DSQ',
+    'DSQ in SQ1'
+  );
+  assert(
+    formatOpenF1SessionSegmentTime(null, { dns: false, dnf: true, dsq: false }, 1) === '',
+    'DNF with missing segment time stays blank'
+  );
+  assert(
+    formatOpenF1SessionSegmentTime(92.171, { dns: false, dnf: true, dsq: false }, 0) === '1:32.171',
+    'DNF driver can still have an SQ1 time'
+  );
 
-const mockResults = [
-  {
-    number: '44',
-    position: '1',
-    driver: mockDrivers[0],
-    constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
-    Q1: '1:29.273',
-    Q2: '1:28.747',
-    Q3: '1:28.376'
-  },
-  {
-    number: '63',
-    position: '2',
-    driver: mockDrivers[1],
-    constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
-    Q1: '1:29.458',
-    Q2: '1:29.012',
-    Q3: '1:28.452'
-  }
-];
+  // 3. Test session matching prefers closest date and circuit
+  console.log('Testing matchOpenF1SprintQualifyingSession...');
+  const sampleSessions: OpenF1Session[] = [
+    {
+      session_key: 9989,
+      session_name: 'Sprint Qualifying',
+      date_start: '2025-03-21T07:30:00+00:00',
+      circuit_short_name: 'Shanghai',
+    },
+    {
+      session_key: 10024,
+      session_name: 'Sprint Qualifying',
+      date_start: '2025-05-02T20:30:00+00:00',
+      circuit_short_name: 'Miami',
+    },
+  ];
 
-const wikitext = generateSprintQualifyingWikitext(mockResults);
-assert(wikitext.includes('====Sprint Qualifying Results===='), 'Wikitext includes correct heading');
-assert(wikitext.includes('SQ1'), 'Wikitext includes SQ1 header');
-assert(wikitext.includes('SQ2'), 'Wikitext includes SQ2 header');
-assert(wikitext.includes('SQ3'), 'Wikitext includes SQ3 header');
-assert(wikitext.includes('Source:<ref name=SQR>'), 'Wikitext includes correct reference name SQR');
-assert(wikitext.includes('final_sprint_qualifying_classification.pdf'), 'Wikitext includes correct FIA file reference');
-assert(wikitext.includes("[[Lewis Hamilton]]"), 'Wikitext contains driver link');
-assert(wikitext.includes("{{Mercedes-CON}}"), 'Wikitext contains team template');
+  const chinaRace = {
+    round: '2',
+    date: '2025-03-23',
+    raceName: 'Chinese Grand Prix',
+    Circuit: { circuitId: 'shanghai' },
+    SprintQualifying: { date: '2025-03-21', time: '07:30:00Z' },
+  };
+  const miamiRace = {
+    round: '6',
+    date: '2025-05-04',
+    raceName: 'Miami Grand Prix',
+    Circuit: { circuitId: 'miami' },
+    SprintQualifying: { date: '2025-05-02', time: '20:30:00Z' },
+  };
 
-console.log("verify-openf1-sync: all assertions passed");
+  assert(
+    matchOpenF1SprintQualifyingSession(sampleSessions, chinaRace, 2)?.session_key === 9989,
+    'China GP matches Shanghai session'
+  );
+  assert(
+    matchOpenF1SprintQualifyingSession(sampleSessions, miamiRace, 6)?.session_key === 10024,
+    'Miami GP matches Miami session'
+  );
+
+  // 4. Test generateSprintQualifyingWikitext
+  console.log('Testing generateSprintQualifyingWikitext...');
+  const mockDrivers = [
+    {
+      driverId: 'hamilton',
+      givenName: 'Lewis',
+      familyName: 'Hamilton',
+      permanentNumber: '44',
+      nationality: 'British',
+      code: 'HAM',
+      dateOfBirth: '',
+      url: '',
+    },
+    {
+      driverId: 'russell',
+      givenName: 'George',
+      familyName: 'Russell',
+      permanentNumber: '63',
+      nationality: 'British',
+      code: 'RUS',
+      dateOfBirth: '',
+      url: '',
+    },
+  ];
+
+  const mockResults = [
+    {
+      number: '44',
+      position: '1',
+      driver: mockDrivers[0],
+      constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
+      Q1: '1:29.273',
+      Q2: '1:28.747',
+      Q3: '1:28.376',
+    },
+    {
+      number: '63',
+      position: '2',
+      driver: mockDrivers[1],
+      constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
+      Q1: '1:29.458',
+      Q2: '1:29.012',
+      Q3: '1:28.452',
+    },
+  ];
+
+  const wikitext = generateSprintQualifyingWikitext(mockResults);
+  assert(wikitext.includes('====Sprint Qualifying Results===='), 'Wikitext includes correct heading');
+  assert(wikitext.includes('SQ1'), 'Wikitext includes SQ1 header');
+  assert(wikitext.includes('SQ2'), 'Wikitext includes SQ2 header');
+  assert(wikitext.includes('SQ3'), 'Wikitext includes SQ3 header');
+  assert(wikitext.includes('Source:<ref name=SQR>'), 'Wikitext includes correct reference name SQR');
+  assert(wikitext.includes('final_sprint_qualifying_classification.pdf'), 'Wikitext includes correct FIA file reference');
+  assert(wikitext.includes('[[Lewis Hamilton]]'), 'Wikitext contains driver link');
+  assert(wikitext.includes('{{Mercedes-CON}}'), 'Wikitext contains team template');
+
+  // 5. Test OpenF1 in-flight deduplication
+  console.log('Testing fetchOpenF1Json in-flight dedup...');
+  const ctx = createF1ApiContext();
+  const url = 'https://api.openf1.org/v1/sessions?session_name=Sprint%20Qualifying&year=2025';
+  const [first, second] = await Promise.all([
+    fetchOpenF1Json<OpenF1Session[]>(url, ctx, 86400 * 7),
+    fetchOpenF1Json<OpenF1Session[]>(url, ctx, 86400 * 7),
+  ]);
+  assert(Array.isArray(first) && first.length > 0, 'First OpenF1 fetch returns sessions');
+  assert(first === second, 'In-flight dedup returns same cached array reference');
+  assert(ctx.apiCallCount === 1, 'Parallel OpenF1 requests share one network call');
+
+  // 6. Integration test: Miami 2025 with standings and pre-fetched drivers
+  console.log('Testing getOpenF1SprintQualifyingResult integration...');
+  const integrationCtx = createF1ApiContext();
+  integrationCtx.schedule = [miamiRace];
+  const currentDrivers = await getDriverStandings(2025, 6, integrationCtx);
+  const roundData = await fetchRoundJolpicaData(
+    2025,
+    6,
+    {
+      needQuali: false,
+      needGpResults: false,
+      needSprintResults: false,
+      needStandings: true,
+      needDrivers: true,
+      hasSprint: true,
+      needSprintQuali: true,
+    },
+    integrationCtx
+  );
+
+  assert(roundData.sprintQualiResults.length === 20, 'Miami 2025 returns 20 SQ results');
+  assert(roundData.sprintQualiResults[0].Q3.length > 0, 'Pole position has SQ3 time');
+  assert(
+    integrationCtx.apiCallCount <= 8,
+    `Constructor mapping stays efficient (got ${integrationCtx.apiCallCount} API calls, expected <= 8)`
+  );
+
+  const directResults = await getOpenF1SprintQualifyingResult(
+    2025,
+    6,
+    miamiRace,
+    integrationCtx,
+    currentDrivers,
+    null,
+    roundData.drivers
+  );
+  assert(directResults.length === 20, 'Direct OpenF1 call with shared drivers also returns 20 results');
+  assert(
+    integrationCtx.apiCallCount <= 8,
+    'Reusing ctx cache does not add network calls for session/results'
+  );
+
+  console.log('verify-openf1-sync: all assertions passed');
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/verify-openf1-sync.ts
+++ b/scripts/verify-openf1-sync.ts
@@ -1,0 +1,72 @@
+import { formatOpenF1Time, getOpenF1SprintQualifyingResult } from '../src/f1-api';
+import { generateSprintQualifyingWikitext } from '../src/wikitext-generator';
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(message);
+}
+
+// 1. Test formatOpenF1Time
+console.log("Testing formatOpenF1Time...");
+assert(formatOpenF1Time(89.273) === '1:29.273', 'Hamilton pole time format');
+assert(formatOpenF1Time(9.005) === '09.005', 'Single digit seconds format');
+assert(formatOpenF1Time(0) === '00.000', 'Zero seconds format');
+assert(formatOpenF1Time(null) === '', 'Null format');
+assert(formatOpenF1Time(undefined) === '', 'Undefined format');
+
+// 2. Test generateSprintQualifyingWikitext
+console.log("Testing generateSprintQualifyingWikitext...");
+const mockDrivers = [
+  {
+    driverId: 'hamilton',
+    givenName: 'Lewis',
+    familyName: 'Hamilton',
+    permanentNumber: '44',
+    nationality: 'British',
+    code: 'HAM',
+    dateOfBirth: '',
+    url: ''
+  },
+  {
+    driverId: 'russell',
+    givenName: 'George',
+    familyName: 'Russell',
+    permanentNumber: '63',
+    nationality: 'British',
+    code: 'RUS',
+    dateOfBirth: '',
+    url: ''
+  }
+];
+
+const mockResults = [
+  {
+    number: '44',
+    position: '1',
+    driver: mockDrivers[0],
+    constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
+    Q1: '1:29.273',
+    Q2: '1:28.747',
+    Q3: '1:28.376'
+  },
+  {
+    number: '63',
+    position: '2',
+    driver: mockDrivers[1],
+    constructor: { constructorId: 'mercedes', name: 'Mercedes', nationality: 'German', url: '' },
+    Q1: '1:29.458',
+    Q2: '1:29.012',
+    Q3: '1:28.452'
+  }
+];
+
+const wikitext = generateSprintQualifyingWikitext(mockResults);
+assert(wikitext.includes('====Sprint Qualifying Results===='), 'Wikitext includes correct heading');
+assert(wikitext.includes('SQ1'), 'Wikitext includes SQ1 header');
+assert(wikitext.includes('SQ2'), 'Wikitext includes SQ2 header');
+assert(wikitext.includes('SQ3'), 'Wikitext includes SQ3 header');
+assert(wikitext.includes('Source:<ref name=SQR>'), 'Wikitext includes correct reference name SQR');
+assert(wikitext.includes('final_sprint_qualifying_classification.pdf'), 'Wikitext includes correct FIA file reference');
+assert(wikitext.includes("[[Lewis Hamilton]]"), 'Wikitext contains driver link');
+assert(wikitext.includes("{{Mercedes-CON}}"), 'Wikitext contains team template');
+
+console.log("verify-openf1-sync: all assertions passed");

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -32,6 +32,7 @@ assert(
 const sprintTiming = {
   hasSprint: true,
   isQualiConcluded: false,
+  isSprintQualiConcluded: false,
   isSprintConcluded: false,
   isRaceConcluded: false,
   isFp1Concluded: true,

--- a/scripts/verify-sync-kv.ts
+++ b/scripts/verify-sync-kv.ts
@@ -74,16 +74,20 @@ const timing = {
   isFp1Concluded: true,
   isFp2Concluded: true,
   isFp3Concluded: true,
+  isSprintQualiConcluded: true,
 };
 
 assert(gpPageSectionRequired('sprint_results', timing), 'Sprint results required on sprint weekend');
 assert(!gpPageSectionRequired('sprint_results', { ...timing, hasSprint: false }), 'No sprint results without sprint');
+assert(gpPageSectionRequired('sprint_qualifying', timing), 'Sprint qualifying results required on sprint weekend when concluded');
+assert(!gpPageSectionRequired('sprint_qualifying', { ...timing, isSprintQualiConcluded: false }), 'Sprint qualifying results not required before conclusion');
 
 const allSynced = allRequiredGpPageSectionsSynced(
   {
     qualifying: true,
     grid: true,
     sprint_results: true,
+    sprint_qualifying: true,
     race_results: true,
     standings: true,
     infobox: true,
@@ -99,6 +103,7 @@ const allSynced = allRequiredGpPageSectionsSynced(
     fp1_report: true,
     fp2_report: true,
     fp3_report: true,
+    entry_list: true,
   },
   timing
 );

--- a/src/f1-api-cache.ts
+++ b/src/f1-api-cache.ts
@@ -25,6 +25,7 @@ export interface CachedScheduleRace {
   Qualifying?: { date: string; time?: string };
   Sprint?: { date: string; time?: string };
   FirstPractice?: { date: string; time?: string };
+  SprintQualifying?: { date: string; time?: string };
 }
 
 export interface F1ApiContext {

--- a/src/f1-api-cache.ts
+++ b/src/f1-api-cache.ts
@@ -22,6 +22,8 @@ export interface CachedScheduleRace {
   round: string;
   date: string;
   time?: string;
+  raceName?: string;
+  Circuit?: { circuitId?: string };
   Qualifying?: { date: string; time?: string };
   Sprint?: { date: string; time?: string };
   FirstPractice?: { date: string; time?: string };

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -658,7 +658,8 @@ export async function fetchRoundJolpicaData(
         race,
         ctx,
         currentDrivers,
-        prevDrivers
+        prevDrivers,
+        drivers
       ).catch(e => {
         console.error("Failed to fetch OpenF1 Sprint Qualifying results:", e);
         return [];
@@ -1020,6 +1021,9 @@ export interface OpenF1Session {
   session_key: number;
   session_name: string;
   date_start: string;
+  circuit_short_name?: string;
+  circuit_key?: number;
+  meeting_key?: number;
 }
 
 export interface OpenF1SessionResult {
@@ -1032,15 +1036,87 @@ export interface OpenF1SessionResult {
   dsq: boolean;
 }
 
+const OPENF1_SESSION_MATCH_WINDOW_DAYS = 4;
+
+function normalizeCircuitToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function circuitsMatch(scheduleCircuitId: string, openF1ShortName: string): boolean {
+  const scheduleToken = normalizeCircuitToken(scheduleCircuitId);
+  const openF1Token = normalizeCircuitToken(openF1ShortName);
+  if (!scheduleToken || !openF1Token) return false;
+  if (scheduleToken === openF1Token || scheduleToken.includes(openF1Token) || openF1Token.includes(scheduleToken)) {
+    return true;
+  }
+
+  const aliasGroups = [
+    ['americas', 'austin'],
+    ['spa', 'spafrancorchamps'],
+    ['ricard', 'lecastellet'],
+    ['redbullring', 'spielberg'],
+    ['hungaroring', 'hungaroring'],
+    ['marinabay', 'marinabay', 'singapore'],
+  ];
+  return aliasGroups.some(group =>
+    group.some(token => scheduleToken.includes(token) || token.includes(scheduleToken)) &&
+    group.some(token => openF1Token.includes(token) || token.includes(openF1Token))
+  );
+}
+
+/** Pick the closest Sprint Qualifying session for a race weekend (exported for tests). */
+export function matchOpenF1SprintQualifyingSession(
+  sessions: OpenF1Session[],
+  race: CachedScheduleRace,
+  round: number
+): OpenF1Session | undefined {
+  const targetDateStr = race.SprintQualifying?.date ?? race.date;
+  const targetDate = new Date(`${targetDateStr}T12:00:00Z`);
+  const circuitId = race.Circuit?.circuitId;
+
+  let candidates = sessions;
+  if (circuitId) {
+    const byCircuit = sessions.filter(session =>
+      session.circuit_short_name && circuitsMatch(circuitId, session.circuit_short_name)
+    );
+    if (byCircuit.length > 0) {
+      candidates = byCircuit;
+    }
+  }
+
+  let best: OpenF1Session | undefined;
+  let bestDiffMs = Infinity;
+  for (const session of candidates) {
+    const sessionDate = new Date(session.date_start);
+    const diffMs = Math.abs(sessionDate.getTime() - targetDate.getTime());
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    if (diffDays <= OPENF1_SESSION_MATCH_WINDOW_DAYS && diffMs < bestDiffMs) {
+      best = session;
+      bestDiffMs = diffMs;
+    }
+  }
+
+  if (!best) {
+    const raceName = race.raceName || 'Unknown';
+    console.warn(`No matching OpenF1 Sprint Qualifying session found for round ${round} (${raceName})`);
+  }
+  return best;
+}
+
 export async function fetchOpenF1Json<T>(
   url: string,
   ctx?: F1ApiContext,
   expirationTtl?: number
 ): Promise<T> {
   const cacheKey = `openf1:${url}`;
+  if (ctx?.cache.has(cacheKey)) {
+    return ctx.cache.get(cacheKey) as T;
+  }
+
   if (ctx) {
-    if (ctx.cache.has(cacheKey)) {
-      return ctx.cache.get(cacheKey) as T;
+    const existing = ctx.inFlight.get(cacheKey);
+    if (existing) {
+      return existing as Promise<T>;
     }
   }
 
@@ -1048,32 +1124,46 @@ export async function fetchOpenF1Json<T>(
     const raw = await ctx.kv.get(`f1_api_cache:${cacheKey}`);
     if (raw) {
       const data = JSON.parse(raw);
-      if (ctx) ctx.cache.set(cacheKey, data);
+      ctx.cache.set(cacheKey, data);
       return data;
     }
   }
 
-  console.log(`Fetching from OpenF1: ${url}`);
-  if (ctx) ctx.apiCallCount++;
+  const promise = (async (): Promise<T> => {
+    console.log(`Fetching from OpenF1: ${url}`);
+    if (ctx) ctx.apiCallCount++;
 
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`OpenF1 API error: ${res.statusText}`);
-  }
-  const rawText = await res.text();
-  const data = JSON.parse(rawText);
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`OpenF1 API error: ${res.statusText}`);
+    }
+    const rawText = await res.text();
+    const data = JSON.parse(rawText);
 
-  if (ctx) {
-    ctx.cache.set(cacheKey, data);
-    if (ctx.kv) {
-      if (expirationTtl !== undefined) {
-        await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText, { expirationTtl });
-      } else {
-        await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText);
+    if (ctx) {
+      ctx.cache.set(cacheKey, data);
+      if (ctx.kv) {
+        if (expirationTtl !== undefined) {
+          await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText, { expirationTtl });
+        } else {
+          await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText);
+        }
       }
     }
+    return data;
+  })();
+
+  if (ctx) {
+    ctx.inFlight.set(cacheKey, promise);
   }
-  return data;
+
+  try {
+    return await promise;
+  } finally {
+    if (ctx) {
+      ctx.inFlight.delete(cacheKey);
+    }
+  }
 }
 
 export function formatOpenF1Time(seconds: number | null | undefined): string {
@@ -1088,6 +1178,56 @@ export function formatOpenF1Time(seconds: number | null | undefined): string {
     return `${minutes}:${secInt}.${secDec}`;
   }
   return `${secInt}.${secDec}`;
+}
+
+/** Format a single SQ segment, handling DNS/DSQ and missing times (exported for tests). */
+export function formatOpenF1SessionSegmentTime(
+  seconds: number | null | undefined,
+  result: Pick<OpenF1SessionResult, 'dns' | 'dsq' | 'dnf'>,
+  segmentIndex: number
+): string {
+  if (result.dns) return segmentIndex === 0 ? 'DNS' : '';
+  if (result.dsq) return segmentIndex === 0 ? 'DSQ' : '';
+  if (seconds === null || seconds === undefined) return '';
+  return formatOpenF1Time(seconds);
+}
+
+function buildConstructorLookup(
+  currentDrivers?: DriverStanding[],
+  prevDrivers?: DriverStanding[] | null
+): Map<string, Constructor> {
+  const lookup = new Map<string, Constructor>();
+  for (const standing of currentDrivers ?? []) {
+    if (standing.Constructors?.[0]) {
+      lookup.set(standing.Driver.driverId, standing.Constructors[0]);
+    }
+  }
+  for (const standing of prevDrivers ?? []) {
+    if (!lookup.has(standing.Driver.driverId) && standing.Constructors?.[0]) {
+      lookup.set(standing.Driver.driverId, standing.Constructors[0]);
+    }
+  }
+  return lookup;
+}
+
+async function resolveConstructorsForDrivers(
+  year: number,
+  driverIds: string[],
+  ctx: F1ApiContext | undefined,
+  currentDrivers: DriverStanding[] | undefined,
+  prevDrivers: DriverStanding[] | null | undefined
+): Promise<Map<string, Constructor>> {
+  const lookup = buildConstructorLookup(currentDrivers, prevDrivers);
+  const missingIds = [...new Set(driverIds)].filter(id => !lookup.has(id));
+  if (missingIds.length === 0) return lookup;
+
+  await Promise.all(
+    missingIds.map(async driverId => {
+      const constructor = await getDriverConstructorForSeason(year, driverId, ctx);
+      if (constructor) lookup.set(driverId, constructor);
+    })
+  );
+  return lookup;
 }
 
 export async function getDriverConstructorForSeason(
@@ -1131,7 +1271,8 @@ export async function getOpenF1SprintQualifyingResult(
   race: CachedScheduleRace,
   ctx?: F1ApiContext,
   currentDrivers?: DriverStanding[],
-  prevDrivers?: DriverStanding[] | null
+  prevDrivers?: DriverStanding[] | null,
+  driversForRound?: Driver[]
 ): Promise<QualifyingResult[]> {
   const sessionsUrl = `https://api.openf1.org/v1/sessions?session_name=Sprint%20Qualifying&year=${year}`;
   let sessions = await fetchOpenF1Json<OpenF1Session[]>(sessionsUrl, ctx, 86400 * 7);
@@ -1146,18 +1287,10 @@ export async function getOpenF1SprintQualifyingResult(
     return [];
   }
 
-  const raceDate = new Date(`${race.date}T12:00:00Z`);
-  const matchedSession = sessions.find(session => {
-    const sessionDate = new Date(session.date_start);
-    const diffMs = Math.abs(sessionDate.getTime() - raceDate.getTime());
-    const diffDays = diffMs / (1000 * 60 * 60 * 24);
-    return diffDays <= 4;
-  });
-
-  const raceName = (race as any).raceName || 'Unknown';
+  const matchedSession = matchOpenF1SprintQualifyingSession(sessions, race, round);
+  const raceName = race.raceName || 'Unknown';
 
   if (!matchedSession) {
-    console.warn(`No matching OpenF1 Sprint Qualifying session found for round ${round} (${raceName})`);
     return [];
   }
 
@@ -1172,12 +1305,11 @@ export async function getOpenF1SprintQualifyingResult(
   }
 
   results.sort((a, b) => a.position - b.position);
-  const drivers = await getDriversForRaceWithFallback(year, round, ctx).catch(() => []);
+  const drivers = driversForRound ?? await getDriversForRaceWithFallback(year, round, ctx).catch(() => []);
 
-  const mappedResults: QualifyingResult[] = [];
+  const resolvedDrivers: Driver[] = [];
   for (const r of results) {
     const driverNumStr = r.driver_number.toString();
-    
     let driver = drivers.find(d => d.permanentNumber === driverNumStr);
     if (!driver && currentDrivers) {
       const standing = currentDrivers.find(s => s.Driver.permanentNumber === driverNumStr);
@@ -1199,30 +1331,38 @@ export async function getOpenF1SprintQualifyingResult(
         nationality: ``,
       };
     }
+    resolvedDrivers.push(driver);
+  }
 
-    const constructor = await getDriverConstructor(year, driver.driverId, ctx, currentDrivers, prevDrivers) || {
-      constructorId: 'unknown',
-      url: '',
-      name: 'Unknown',
-      nationality: ''
-    };
+  const constructorLookup = await resolveConstructorsForDrivers(
+    year,
+    resolvedDrivers.map(driver => driver.driverId),
+    ctx,
+    currentDrivers,
+    prevDrivers
+  );
 
-    const formatSQTime = (sec: number | null | undefined): string => {
-      if (sec === null || sec === undefined) return '';
-      return formatOpenF1Time(sec);
-    };
+  const unknownConstructor: Constructor = {
+    constructorId: 'unknown',
+    url: '',
+    name: 'Unknown',
+    nationality: '',
+  };
 
-    mappedResults.push({
+  return results.map((r, index) => {
+    const driverNumStr = r.driver_number.toString();
+    const driver = resolvedDrivers[index];
+    const constructor = constructorLookup.get(driver.driverId) ?? unknownConstructor;
+
+    return {
       number: driverNumStr,
       position: r.position.toString(),
       driver,
       constructor,
-      Q1: formatSQTime(r.duration?.[0]),
-      Q2: formatSQTime(r.duration?.[1]),
-      Q3: formatSQTime(r.duration?.[2]),
-    });
-  }
-
-  return mappedResults;
+      Q1: formatOpenF1SessionSegmentTime(r.duration?.[0], r, 0),
+      Q2: formatOpenF1SessionSegmentTime(r.duration?.[1], r, 1),
+      Q3: formatOpenF1SessionSegmentTime(r.duration?.[2], r, 2),
+    };
+  });
 }
 

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -4,7 +4,9 @@ import {
   createF1ApiContextFromEnv,
   F1ApiContext,
   isJolpicaUrlCached,
+  CachedScheduleRace,
 } from './f1-api-cache';
+import { trackedKvPut } from './kv-ops';
 
 export { createF1ApiContext, createF1ApiContextFromEnv, F1ApiContext };
 
@@ -114,6 +116,10 @@ export interface ScheduleRace {
     time?: string;
   };
   Sprint?: {
+    date: string;
+    time?: string;
+  };
+  SprintQualifying?: {
     date: string;
     time?: string;
   };
@@ -598,12 +604,14 @@ export async function fetchRoundJolpicaData(
     needStandings: boolean;
     needDrivers: boolean;
     hasSprint: boolean;
+    needSprintQuali: boolean;
   },
   ctx?: F1ApiContext
 ): Promise<{
   qualiResults: QualifyingResult[];
   gpResults: RaceResult[];
   sprintResults: RaceResult[];
+  sprintQualiResults: QualifyingResult[];
   drivers: Driver[];
   currentDrivers: DriverStanding[];
   prevDrivers: DriverStanding[] | null;
@@ -617,6 +625,7 @@ export async function fetchRoundJolpicaData(
     needStandings,
     needDrivers,
     hasSprint,
+    needSprintQuali,
   } = options;
 
   const [
@@ -636,13 +645,34 @@ export async function fetchRoundJolpicaData(
     needStandings && round > 1 ? getDriverStandings(year, round - 1, ctx).catch(() => null) : Promise.resolve(null),
     needStandings ? getConstructorStandings(year, round, ctx).catch(() => []) : Promise.resolve([]),
     needStandings && round > 1 ? getConstructorStandings(year, round - 1, ctx).catch(() => null) : Promise.resolve(null),
-    needDrivers ? getDriversForRaceWithFallback(year, round, ctx).catch(() => []) : Promise.resolve([]),
+    needDrivers || needSprintQuali ? getDriversForRaceWithFallback(year, round, ctx).catch(() => []) : Promise.resolve([]),
   ]);
+
+  let sprintQualiResults: QualifyingResult[] = [];
+  if (needSprintQuali && hasSprint) {
+    const race = ctx?.schedule?.find(r => parseInt(r.round, 10) === round);
+    if (race) {
+      sprintQualiResults = await getOpenF1SprintQualifyingResult(
+        year,
+        round,
+        race,
+        ctx,
+        currentDrivers,
+        prevDrivers
+      ).catch(e => {
+        console.error("Failed to fetch OpenF1 Sprint Qualifying results:", e);
+        return [];
+      });
+    } else {
+      console.warn(`Could not find race for round ${round} in schedule cache for Sprint Qualifying fetch.`);
+    }
+  }
 
   return {
     qualiResults,
     gpResults,
     sprintResults,
+    sprintQualiResults,
     drivers,
     currentDrivers,
     prevDrivers,
@@ -984,5 +1014,215 @@ export async function fetchFiaEntryListText(year: number, raceName: string): Pro
     console.warn(`Failed to fetch or parse FIA Entry List PDF from ${url}:`, e.message);
     return null;
   }
+}
+
+export interface OpenF1Session {
+  session_key: number;
+  session_name: string;
+  date_start: string;
+}
+
+export interface OpenF1SessionResult {
+  position: number;
+  driver_number: number;
+  duration: (number | null)[];
+  gap_to_leader: (number | null)[];
+  dns: boolean;
+  dnf: boolean;
+  dsq: boolean;
+}
+
+export async function fetchOpenF1Json<T>(
+  url: string,
+  ctx?: F1ApiContext,
+  expirationTtl?: number
+): Promise<T> {
+  const cacheKey = `openf1:${url}`;
+  if (ctx) {
+    if (ctx.cache.has(cacheKey)) {
+      return ctx.cache.get(cacheKey) as T;
+    }
+  }
+
+  if (ctx?.kv) {
+    const raw = await ctx.kv.get(`f1_api_cache:${cacheKey}`);
+    if (raw) {
+      const data = JSON.parse(raw);
+      if (ctx) ctx.cache.set(cacheKey, data);
+      return data;
+    }
+  }
+
+  console.log(`Fetching from OpenF1: ${url}`);
+  if (ctx) ctx.apiCallCount++;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`OpenF1 API error: ${res.statusText}`);
+  }
+  const rawText = await res.text();
+  const data = JSON.parse(rawText);
+
+  if (ctx) {
+    ctx.cache.set(cacheKey, data);
+    if (ctx.kv) {
+      if (expirationTtl !== undefined) {
+        await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText, { expirationTtl });
+      } else {
+        await trackedKvPut(ctx.kv, `f1_api_cache:${cacheKey}`, rawText);
+      }
+    }
+  }
+  return data;
+}
+
+export function formatOpenF1Time(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined) return '';
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = (seconds % 60).toFixed(3);
+  const parts = remainingSeconds.split('.');
+  const secInt = parts[0].padStart(2, '0');
+  const secDec = parts[1] || '000';
+  
+  if (minutes > 0) {
+    return `${minutes}:${secInt}.${secDec}`;
+  }
+  return `${secInt}.${secDec}`;
+}
+
+export async function getDriverConstructorForSeason(
+  year: number,
+  driverId: string,
+  ctx?: F1ApiContext
+): Promise<Constructor | null> {
+  const url = `${BASE_URL}/${year}/drivers/${driverId}/constructors.json`;
+  try {
+    return await cachedJolpicaJson(url, ctx, (data: any) => {
+      const list = data?.MRData?.ConstructorTable?.Constructors;
+      return list && list.length > 0 ? list[0] : null;
+    });
+  } catch (e) {
+    console.error(`Failed to fetch constructor for driver ${driverId} in season ${year}:`, e);
+    return null;
+  }
+}
+
+export async function getDriverConstructor(
+  year: number,
+  driverId: string,
+  ctx?: F1ApiContext,
+  currentDrivers?: DriverStanding[],
+  prevDrivers?: DriverStanding[] | null
+): Promise<Constructor | null> {
+  if (currentDrivers) {
+    const s = currentDrivers.find(x => x.Driver.driverId === driverId);
+    if (s && s.Constructors && s.Constructors.length > 0) return s.Constructors[0];
+  }
+  if (prevDrivers) {
+    const s = prevDrivers.find(x => x.Driver.driverId === driverId);
+    if (s && s.Constructors && s.Constructors.length > 0) return s.Constructors[0];
+  }
+  return getDriverConstructorForSeason(year, driverId, ctx);
+}
+
+export async function getOpenF1SprintQualifyingResult(
+  year: number,
+  round: number,
+  race: CachedScheduleRace,
+  ctx?: F1ApiContext,
+  currentDrivers?: DriverStanding[],
+  prevDrivers?: DriverStanding[] | null
+): Promise<QualifyingResult[]> {
+  const sessionsUrl = `https://api.openf1.org/v1/sessions?session_name=Sprint%20Qualifying&year=${year}`;
+  let sessions = await fetchOpenF1Json<OpenF1Session[]>(sessionsUrl, ctx, 86400 * 7);
+  
+  if ((!sessions || sessions.length === 0) && sessionsUrl.includes('session_name=Sprint%20Qualifying')) {
+    const fallbackUrl = sessionsUrl.replace('session_name=Sprint%20Qualifying', 'session_name=Sprint%20Shootout');
+    sessions = await fetchOpenF1Json<OpenF1Session[]>(fallbackUrl, ctx, 86400 * 7);
+  }
+
+  if (!sessions || sessions.length === 0) {
+    console.warn(`No OpenF1 Sprint Qualifying sessions found for year ${year}`);
+    return [];
+  }
+
+  const raceDate = new Date(`${race.date}T12:00:00Z`);
+  const matchedSession = sessions.find(session => {
+    const sessionDate = new Date(session.date_start);
+    const diffMs = Math.abs(sessionDate.getTime() - raceDate.getTime());
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    return diffDays <= 4;
+  });
+
+  const raceName = (race as any).raceName || 'Unknown';
+
+  if (!matchedSession) {
+    console.warn(`No matching OpenF1 Sprint Qualifying session found for round ${round} (${raceName})`);
+    return [];
+  }
+
+  console.log(`Matched OpenF1 session_key ${matchedSession.session_key} for ${raceName}`);
+
+  const resultsUrl = `https://api.openf1.org/v1/session_result?session_key=${matchedSession.session_key}`;
+  const results = await fetchOpenF1Json<OpenF1SessionResult[]>(resultsUrl, ctx, 86400);
+
+  if (!results || results.length === 0) {
+    console.warn(`No OpenF1 session results found for session_key ${matchedSession.session_key}`);
+    return [];
+  }
+
+  results.sort((a, b) => a.position - b.position);
+  const drivers = await getDriversForRaceWithFallback(year, round, ctx).catch(() => []);
+
+  const mappedResults: QualifyingResult[] = [];
+  for (const r of results) {
+    const driverNumStr = r.driver_number.toString();
+    
+    let driver = drivers.find(d => d.permanentNumber === driverNumStr);
+    if (!driver && currentDrivers) {
+      const standing = currentDrivers.find(s => s.Driver.permanentNumber === driverNumStr);
+      if (standing) driver = standing.Driver;
+    }
+    if (!driver && prevDrivers) {
+      const standing = prevDrivers.find(s => s.Driver.permanentNumber === driverNumStr);
+      if (standing) driver = standing.Driver;
+    }
+    if (!driver) {
+      driver = {
+        driverId: `driver_${driverNumStr}`,
+        permanentNumber: driverNumStr,
+        code: `DRV`,
+        url: ``,
+        givenName: `Driver`,
+        familyName: `#${driverNumStr}`,
+        dateOfBirth: ``,
+        nationality: ``,
+      };
+    }
+
+    const constructor = await getDriverConstructor(year, driver.driverId, ctx, currentDrivers, prevDrivers) || {
+      constructorId: 'unknown',
+      url: '',
+      name: 'Unknown',
+      nationality: ''
+    };
+
+    const formatSQTime = (sec: number | null | undefined): string => {
+      if (sec === null || sec === undefined) return '';
+      return formatOpenF1Time(sec);
+    };
+
+    mappedResults.push({
+      number: driverNumStr,
+      position: r.position.toString(),
+      driver,
+      constructor,
+      Q1: formatSQTime(r.duration?.[0]),
+      Q2: formatSQTime(r.duration?.[1]),
+      Q3: formatSQTime(r.duration?.[2]),
+    });
+  }
+
+  return mappedResults;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { 
   generateGridWikitext, 
   generateQualifyingWikitext, 
+  generateSprintQualifyingWikitext,
   generateRaceWikitext, 
   generateStandingsWikitext,
   generatePracticeWikitext,
@@ -719,6 +720,17 @@ export default {
         }
         const isQualiConcluded = now >= qualiEndTime;
 
+        let sprintQualiEndTime: Date | null = null;
+        if (race.SprintQualifying) {
+          const sprintQualiStartTime = new Date(`${race.SprintQualifying.date}T${race.SprintQualifying.time || "00:00:00Z"}`);
+          sprintQualiEndTime = new Date(sprintQualiStartTime.getTime() + 60 * 60 * 1000);
+        } else if (race.Sprint) {
+          sprintQualiEndTime = new Date(`${race.date}T00:00:00Z`);
+          sprintQualiEndTime.setUTCDate(sprintQualiEndTime.getUTCDate() - 2);
+          sprintQualiEndTime = new Date(sprintQualiEndTime.getTime() + 18 * 60 * 60 * 1000);
+        }
+        const isSprintQualiConcluded = sprintQualiEndTime ? now >= sprintQualiEndTime : false;
+
         const fp1EndTime = getPracticeEndTime(race.FirstPractice);
         const fp2EndTime = getPracticeEndTime(race.SecondPractice);
         const fp3EndTime = getPracticeEndTime(race.ThirdPractice);
@@ -748,6 +760,7 @@ export default {
         const pageTiming = {
           hasSprint: !!race.Sprint,
           isQualiConcluded,
+          isSprintQualiConcluded,
           isSprintConcluded,
           isRaceConcluded,
           isFp1Concluded,
@@ -802,6 +815,7 @@ export default {
         const isGpPageSectionSynced = (section: GpPageSection): boolean =>
           gpPageSectionState[section] === true;
 
+        const needSprintQuali = needGpPage && !!race.Sprint && isSprintQualiConcluded;
         const needQuali = needGpPage && isQualiConcluded;
         const needGpResults = needGpCareerTemplate || needStats || (needGpPage && isRaceConcluded);
         const needSprintResults = needSprintTemplate || (needGpPage && isSprintConcluded);
@@ -809,6 +823,7 @@ export default {
         const needDrivers = needGpPage && (
           isBackgroundTime ||
           isQualiConcluded ||
+          isSprintQualiConcluded ||
           isSprintConcluded ||
           isRaceConcluded ||
           isFp1Concluded ||
@@ -819,13 +834,14 @@ export default {
         let qualiResults: any[] = [];
         let gpResults: any[] = [];
         let sprintResults: any[] = [];
+        let sprintQualiResults: any[] = [];
         let drivers: any[] = [];
         let currentDrivers: any[] = [];
         let prevDrivers: any = null;
         let currentConstructors: any[] = [];
         let prevConstructors: any = null;
 
-        if (needQuali || needGpResults || needSprintResults || needStandings || needDrivers) {
+        if (needQuali || needGpResults || needSprintResults || needStandings || needDrivers || needSprintQuali) {
           const roundData = await fetchRoundJolpicaData(
             year,
             round,
@@ -836,12 +852,14 @@ export default {
               needStandings,
               needDrivers,
               hasSprint: !!race.Sprint,
+              needSprintQuali,
             },
             apiCtx
           );
           qualiResults = roundData.qualiResults;
           gpResults = roundData.gpResults;
           sprintResults = roundData.sprintResults;
+          sprintQualiResults = roundData.sprintQualiResults;
           drivers = roundData.drivers;
           currentDrivers = roundData.currentDrivers;
           prevDrivers = roundData.prevDrivers;
@@ -1244,7 +1262,18 @@ export default {
               }
             }
 
-            if (isQualiConcluded || isSprintConcluded || isRaceConcluded) {
+            if (isQualiConcluded || isSprintQualiConcluded || isSprintConcluded || isRaceConcluded) {
+              if (race.Sprint && isSprintQualiConcluded && sprintQualiResults && sprintQualiResults.length > 0 && !isGpPageSectionSynced('sprint_qualifying')) {
+                const sprintQualiWikitext = generateSprintQualifyingWikitext(sprintQualiResults);
+                const bestSprintQualiHeader = findBestHeader(updatedContent, ["==== Sprint Qualifying Results ====", "====Sprint Qualifying Results====", "=== Sprint Qualifying ===", "===Sprint Qualifying==="], "==== Sprint Qualifying Results ====");
+                const newContent = replaceSectionWikitext(updatedContent, bestSprintQualiHeader, sprintQualiWikitext);
+                if (newContent !== updatedContent) {
+                  updatedContent = newContent;
+                  changes.push("Sprint Qualifying Results");
+                }
+                await markGpPageSectionSynced('sprint_qualifying');
+              }
+
               if (isQualiConcluded && qualiResults && qualiResults.length > 0) {
                 if (!isGpPageSectionSynced('qualifying')) {
                   const qualifyingWikitext = generateQualifyingWikitext(qualiResults);

--- a/src/index.ts
+++ b/src/index.ts
@@ -819,7 +819,7 @@ export default {
         const needQuali = needGpPage && isQualiConcluded;
         const needGpResults = needGpCareerTemplate || needStats || (needGpPage && isRaceConcluded);
         const needSprintResults = needSprintTemplate || (needGpPage && isSprintConcluded);
-        const needStandings = needGpPage && (isRaceConcluded || isBackgroundTime);
+        const needStandings = needGpPage && (isRaceConcluded || isBackgroundTime || needSprintQuali);
         const needDrivers = needGpPage && (
           isBackgroundTime ||
           isQualiConcluded ||
@@ -1003,6 +1003,7 @@ export default {
 
             let updatedContent = currentContent;
             let changes: string[] = [];
+            const pendingGpPageSections: GpPageSection[] = [];
             const raceResults = gpResults;
             const racingKey = getF1RacingKey(race.raceName);
 
@@ -1265,13 +1266,13 @@ export default {
             if (isQualiConcluded || isSprintQualiConcluded || isSprintConcluded || isRaceConcluded) {
               if (race.Sprint && isSprintQualiConcluded && sprintQualiResults && sprintQualiResults.length > 0 && !isGpPageSectionSynced('sprint_qualifying')) {
                 const sprintQualiWikitext = generateSprintQualifyingWikitext(sprintQualiResults);
-                const bestSprintQualiHeader = findBestHeader(updatedContent, ["==== Sprint Qualifying Results ====", "====Sprint Qualifying Results====", "=== Sprint Qualifying ===", "===Sprint Qualifying==="], "==== Sprint Qualifying Results ====");
+                const bestSprintQualiHeader = findBestHeader(updatedContent, ["====Sprint Qualifying Results====", "==== Sprint Qualifying Results ====", "=== Sprint Qualifying ===", "===Sprint Qualifying==="], "====Sprint Qualifying Results====");
                 const newContent = replaceSectionWikitext(updatedContent, bestSprintQualiHeader, sprintQualiWikitext);
                 if (newContent !== updatedContent) {
                   updatedContent = newContent;
                   changes.push("Sprint Qualifying Results");
                 }
-                await markGpPageSectionSynced('sprint_qualifying');
+                pendingGpPageSections.push('sprint_qualifying');
               }
 
               if (isQualiConcluded && qualiResults && qualiResults.length > 0) {
@@ -1539,8 +1540,14 @@ export default {
                 apiEndpoint
               );
               console.log(`  Successfully published ${gpPageTitle}!`);
+              for (const section of pendingGpPageSections) {
+                await markGpPageSectionSynced(section);
+              }
             } else {
               console.log(`  No updates needed for GP page ${gpPageTitle} sections.`);
+              for (const section of pendingGpPageSections) {
+                await markGpPageSectionSynced(section);
+              }
             }
           } catch (e: any) {
             console.error(`Error updating GP page sections for round ${round}:`, e.message);

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -9,6 +9,7 @@ export type GpPageSection =
   | 'qualifying'
   | 'grid'
   | 'sprint_results'
+  | 'sprint_qualifying'
   | 'race_results'
   | 'standings'
   | 'infobox'
@@ -78,6 +79,7 @@ export const GP_PAGE_SECTIONS: GpPageSection[] = [
   'qualifying',
   'grid',
   'sprint_results',
+  'sprint_qualifying',
   'race_results',
   'standings',
   'infobox',
@@ -129,6 +131,7 @@ export function gpPageSectionRequired(
   options: {
     hasSprint: boolean;
     isQualiConcluded: boolean;
+    isSprintQualiConcluded?: boolean;
     isSprintConcluded: boolean;
     isRaceConcluded: boolean;
     isFp1Concluded: boolean;
@@ -140,6 +143,7 @@ export function gpPageSectionRequired(
   const {
     hasSprint,
     isQualiConcluded,
+    isSprintQualiConcluded = false,
     isSprintConcluded,
     isRaceConcluded,
     isFp1Concluded,
@@ -156,6 +160,8 @@ export function gpPageSectionRequired(
     case 'q2_report':
     case 'q3_report':
       return isQualiConcluded;
+    case 'sprint_qualifying':
+      return hasSprint && isSprintQualiConcluded;
     case 'sprint_results':
     case 'sprint_report':
       return hasSprint && isSprintConcluded;
@@ -185,6 +191,7 @@ export function allRequiredGpPageSectionsSynced(
   options: {
     hasSprint: boolean;
     isQualiConcluded: boolean;
+    isSprintQualiConcluded?: boolean;
     isSprintConcluded: boolean;
     isRaceConcluded: boolean;
     isFp1Concluded: boolean;

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -314,6 +314,157 @@ The full qualifying results for the '''{{PAGENAME}}''' are outlined below:
   return output;
 }
 
+// Generate SPRINT QUALIFYING results wikitext
+export function generateSprintQualifyingWikitext(qualifyingResults: QualifyingResult[]): string {
+  if (qualifyingResults.length === 0) return 'No sprint qualifying data available.';
+
+  const totalDrivers = qualifyingResults.length;
+  const q3Count = Math.min(10, totalDrivers);
+  const q2ElimCount = Math.max(0, Math.floor((totalDrivers - q3Count) / 2));
+  const q1ElimCount = Math.max(0, totalDrivers - q3Count - q2ElimCount);
+
+  // Sort lists for position classification
+  const sortQ1 = [...qualifyingResults].sort((a, b) => timeToSeconds(a.Q1) - timeToSeconds(b.Q1));
+  const sortQ2 = [...qualifyingResults].sort((a, b) => timeToSeconds(a.Q2 || '') - timeToSeconds(b.Q2 || ''));
+
+  // Find driver number with fastest time in Q1 & Q2
+  let fastestQ1Number = '';
+  for (const q of sortQ1) {
+    if (q.Q1 && q.Q1 !== 'nan') {
+      fastestQ1Number = q.number;
+      break;
+    }
+  }
+
+  let fastestQ2Number = '';
+  for (const q of sortQ2) {
+    if (q.Q2 && q.Q2 !== 'nan') {
+      fastestQ2Number = q.number;
+      break;
+    }
+  }
+
+  let oneZeroSevenBase = '';
+  for (const q of qualifyingResults) {
+    if (q.number === fastestQ1Number) {
+      oneZeroSevenBase = q.Q1;
+      break;
+    }
+  }
+
+  let output = `====Sprint Qualifying Results====
+The full Sprint Qualifying results for the '''{{PAGENAME}}''' are outlined below:
+
+{|class="wikitable" width=100% style="font-size:77%"
+! rowspan=2 width=4% | <span style="cursor:help" title="Position">Pos.</span>
+! rowspan=2 width=5% | <span style="cursor:help" title="Car Number">No.</span>
+! rowspan=2 width=23% | Driver
+! rowspan=2 width=23% | Team
+| rowspan=${totalDrivers + 6} width=1px |
+! colspan=2 width=13% | <span style="cursor:help" title="Sprint Qualifying 1">SQ1</span>
+| rowspan=${totalDrivers + 6} width=1px |
+! colspan=2 width=13% | <span style="cursor:help" title="Sprint Qualifying 2">SQ2</span>
+| rowspan=${totalDrivers + 6} width=1px |
+! colspan=2 width=13% | <span style="cursor:help" title="Sprint Qualifying 3">SQ3</span>
+! rowspan=2 width=5% | Grid
+|-
+! width=4% | <span style="cursor:help" title="Position">Pos.</span>
+! width=9% | Time
+! width=4% | <span style="cursor:help" title="Position">Pos.</span>
+! width=9% | Time
+! width=4% | <span style="cursor:help" title="Position">Pos.</span>
+! width=9% | Time`;
+
+  for (let row = 0; row < totalDrivers; row++) {
+    const q = qualifyingResults[row];
+    const team = getTeamTemplate(q.constructor.constructorId, q.constructor.name);
+    const driver = `${getFlag(q.driver.nationality)} [[${q.driver.givenName} ${q.driver.familyName}]]`;
+    const number = q.number;
+    const pos = q.position;
+
+    // Print drop indicators
+    if (row === q3Count || row === q3Count + q2ElimCount) {
+      output += '\n|-\n|colspan=14 style="border-bottom:hidden"|\n|-\n|colspan=14|\n|-';
+    } else {
+      output += '\n|-';
+    }
+
+    output += `\n! ${pos}`;
+    output += `\n| align=center | ${number}`;
+    output += `\n| ${driver}`;
+    output += `\n| ${team}`;
+
+    // SQ1
+    if (row >= q3Count + q2ElimCount) {
+      output += `\n! ${pos}`;
+    } else {
+      const q1Pos = sortQ1.findIndex(x => x.number === number) + 1;
+      output += `\n! ${q1Pos}`;
+    }
+
+    if (fastestQ1Number === number) {
+      output += `\n| '''${q.Q1}'''`;
+    } else {
+      output += `\n| ${q.Q1 || ''}`;
+    }
+
+    // SQ2
+    if (row < q3Count + q2ElimCount) {
+      if (row >= q3Count) {
+        output += `\n! ${pos}`;
+      } else {
+        const q2Pos = sortQ2.findIndex(x => x.number === number) + 1;
+        output += `\n! ${q2Pos}`;
+      }
+
+      if (q.Q2 && q.Q2 !== 'nan') {
+        if (fastestQ2Number === number) {
+          output += `\n| '''${q.Q2}'''`;
+        } else {
+          output += `\n| ${q.Q2}`;
+        }
+      } else {
+        output += `\n| `;
+      }
+    } else if (row === q3Count + q2ElimCount) {
+      output += `\n! rowspan="${q1ElimCount}" |`;
+      output += `\n| rowspan="${q1ElimCount}" |`;
+      output += `\n! rowspan="${q1ElimCount}" |`;
+      output += `\n| rowspan="${q1ElimCount}" |`;
+    }
+
+    // SQ3
+    if (row < q3Count) {
+      output += `\n! ${pos}`;
+      if (q.Q3 && q.Q3 !== 'nan') {
+        if (row === 0) {
+          output += `\n| '''${q.Q3}'''`;
+        } else {
+          output += `\n| ${q.Q3}`;
+        }
+      } else {
+        output += `\n| `;
+      }
+    } else if (row === q3Count) {
+      output += `\n! rowspan="${q2ElimCount}" |`;
+      output += `\n| rowspan="${q2ElimCount}" |`;
+    }
+
+    // Grid
+    output += `\n! ${pos}`;
+  }
+
+  const oneZeroSevenTime = calculate107Time(oneZeroSevenBase);
+  output += `\n|-
+! colspan=14 | [[107% Time]]: ${oneZeroSevenTime}
+|-
+! colspan=14 | Source:<ref name=SQR>[https://www.fia.com/system/files/decision-document/{{lc:{{PAGENAMEE}}}}_-_final_sprint_qualifying_classification.pdf {{PAGENAME}} - Final Sprint Qualifying Classification] (PDF). Fédération Internationale de l'Automobile.</ref>
+|}`;
+  output += "\n*'''Bold''' indicates the fastest driver's time in each session.";
+
+  return output;
+}
+
 // Generate RACE or SPRINT results wikitext
 export function generateRaceWikitext(results: RaceResult[], isSprint = false): string {
   if (results.length === 0) return `No ${isSprint ? 'sprint' : 'race'} data available.`;


### PR DESCRIPTION
# Sprint Qualifying Cron Sync

At my request, Antigravity used Gemini Flash 3.5 (High) to implement the automated cron sync for Sprint Qualifying results using the OpenF1 API, verified all logic using unit tests and manual execution, committed the changes to a new feature branch, pushed it to GitHub, and created a pull request.

## Changes Made

### 1. F1 API Caching & Types
* **[f1-api-cache.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/f1-api-cache.ts)**: Added the `SprintQualifying` schedule sub-property to `CachedScheduleRace` interface.
* **[f1-api.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/f1-api.ts)**:
  * Added `SprintQualifying` to `ScheduleRace`.
  * Implemented `fetchOpenF1Json` to fetch and store OpenF1 sessions & results in KV (prefix `f1_api_cache:openf1:`) and memory cache.
  * Implemented `formatOpenF1Time` to format raw seconds (e.g. `89.273`) into the standard `MM:SS.xxx` format (e.g. `1:29.273`).
  * Implemented `getDriverConstructor` to resolve drivers to constructors for the active season by utilizing current standings, previous standings, or a fallback Jolpica constructor lookup.
  * Implemented `getOpenF1SprintQualifyingResult` to fetch the year's Sprint Qualifying sessions, match the session within 4 days of the GP Sunday date (which correctly yields session `11317` for 2026 Silverstone), fetch results, and construct `QualifyingResult[]`.
  * Updated `fetchRoundJolpicaData` to accept `needSprintQuali` in options and retrieve results via the new OpenF1 fetch logic.

### 2. Wikitext Generation
* **[wikitext-generator.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/wikitext-generator.ts)**:
  * Implemented `generateSprintQualifyingWikitext` to compile the `QualifyingResult[]` array into a formatted wikitext table. It mimics the regular Qualifying table but outputs `SQ1`/`SQ2`/`SQ3` column headers,classified positions, 107% time, and links to the FIA document `final_sprint_qualifying_classification.pdf` using reference name `<ref name=SQR>`.

### 3. KV Page Section State
* **[sync-kv.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/sync-kv.ts)**:
  * Added `'sprint_qualifying'` to `GpPageSection` union and `GP_PAGE_SECTIONS` list.
  * Updated `gpPageSectionRequired` and `allRequiredGpPageSectionsSynced` to check if Sprint Qualifying is concluded when a weekend has a sprint.

### 4. Cron Orchestration
* **[index.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/src/index.ts)**:
  * Calculated `sprintQualiEndTime` (Sprint Qualifying start + 1 hour) and check `isSprintQualiConcluded`.
  * Included `isSprintQualiConcluded` in `pageTiming`.
  * Defined `needSprintQuali` condition and batch-fetched it when necessary.
  * Added the block under page section updates to sync `'sprint_qualifying'` with `generateSprintQualifyingWikitext`, replace the wikitext under `==== Sprint Qualifying Results ====`, edit the wiki page on Fandom, and set the KV synced flag.

### 5. Verification tests
* **[verify-sync-kv.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/scripts/verify-sync-kv.ts)** and **[verify-practice-sessions.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/scripts/verify-practice-sessions.ts)**: Updated test suites to encompass the new signatures and assert correct required-state flags for `'sprint_qualifying'`.
* **[verify-openf1-sync.ts](file:///c:/Users/chris/Documents/GitHub/f1-fandom/scripts/verify-openf1-sync.ts)**: Added a new unit test suite checking that `formatOpenF1Time` performs conversions correctly and `generateSprintQualifyingWikitext` outputs valid wikitext.
* **[package.json](file:///c:/Users/chris/Documents/GitHub/f1-fandom/package.json)**: Added `verify-openf1-sync.ts` to `npm test` script.

---

## Verification Results

### Automated Tests
Ran `npm test` successfully (all assertions passed, no type issues):
```bash
verify-sync-kv: all assertions passed
verify-wikitext-parse: all assertions passed
verify-infobox-update: all assertions passed
verify-career-placeholder: all assertions passed
verify-legacy-kv: all assertions passed
verify-stats-sync: all assertions passed
verify-jolpica-cache: all assertions passed
verify-practice-sessions: all assertions passed
verify-llm-reporter: all assertions passed
verify-kv-ops: all assertions passed
verify-entry-list-sync: all assertions passed
Testing formatOpenF1Time...
Testing generateSprintQualifyingWikitext...
verify-openf1-sync: all assertions passed
```

### Manual Verification
Ran a scratch verification script querying actual 2026 Silverstone Sprint Qualifying results from OpenF1:
```
Fetching Sprint Qualifying results from OpenF1...
Fetching from OpenF1: https://api.openf1.org/v1/sessions?session_name=Sprint%20Qualifying&year=2026
Matched OpenF1 session_key 11317 for British Grand Prix
Fetching from OpenF1: https://api.openf1.org/v1/session_result?session_key=11317
Retrieved 22 results.
First 3 results:
Pos 1 - Driver: Lewis Hamilton (HAM), Constructor: Ferrari, SQ1: 1:29.273, SQ2: 1:28.747, SQ3: 1:28.376
Pos 2 - Driver: Kimi Antonelli (ANT), Constructor: Mercedes, SQ1: 1:29.746, SQ2: 1:28.846, SQ3: 1:28.387
Pos 3 - Driver: Max Verstappen (VER), Constructor: Red Bull Racing, SQ1: 1:29.689, SQ2: 1:29.242, SQ3: 1:28.697
```
Generated wikitext was verified to have the correct structure, column labels, formatting (bolding the fastest segment times), 107% time calculation (1:35.522), and reference link.