### PR TITLE
feat: add LLM Sprint Qualifying report generation

### DIFF
--- a/scripts/verify-llm-reporter.ts
+++ b/scripts/verify-llm-reporter.ts
@@ -55,4 +55,28 @@ assert(context.includes('### FP1 Results:'), 'Prompt context includes FP1 sectio
 assert(context.includes('Lando Norris'), 'Prompt context includes driver from practice results');
 assert(context.includes('Austrian Grand Prix'), 'Prompt context includes race name');
 
+const sprintQualiContext = generatePromptContext(
+  race,
+  [],
+  {},
+  [],
+  [],
+  [],
+  undefined,
+  [
+    {
+      number: '1',
+      driver: { givenName: 'Max', familyName: 'Verstappen' },
+      constructor: { name: 'Red Bull Racing' },
+      Q1: '1:24.123',
+      Q2: '1:23.456',
+      Q3: '1:22.789',
+    },
+  ]
+);
+
+assert(sprintQualiContext.includes('### Sprint Qualifying Results:'), 'Prompt context includes Sprint Qualifying section');
+assert(sprintQualiContext.includes('Max Verstappen'), 'Prompt context includes sprint quali pole sitter');
+assert(sprintQualiContext.includes('SQ3: 1:22.789'), 'Prompt context includes SQ3 segment time');
+
 console.log('verify-llm-reporter: all assertions passed');

--- a/scripts/verify-sync-kv.ts
+++ b/scripts/verify-sync-kv.ts
@@ -80,7 +80,9 @@ const timing = {
 assert(gpPageSectionRequired('sprint_results', timing), 'Sprint results required on sprint weekend');
 assert(!gpPageSectionRequired('sprint_results', { ...timing, hasSprint: false }), 'No sprint results without sprint');
 assert(gpPageSectionRequired('sprint_qualifying', timing), 'Sprint qualifying results required on sprint weekend when concluded');
+assert(gpPageSectionRequired('sprint_qualifying_report', timing), 'Sprint qualifying report required on sprint weekend when concluded');
 assert(!gpPageSectionRequired('sprint_qualifying', { ...timing, isSprintQualiConcluded: false }), 'Sprint qualifying results not required before conclusion');
+assert(!gpPageSectionRequired('sprint_qualifying_report', { ...timing, isSprintQualiConcluded: false }), 'Sprint qualifying report not required before conclusion');
 
 const allSynced = allRequiredGpPageSectionsSynced(
   {
@@ -88,6 +90,7 @@ const allSynced = allRequiredGpPageSectionsSynced(
     grid: true,
     sprint_results: true,
     sprint_qualifying: true,
+    sprint_qualifying_report: true,
     race_results: true,
     standings: true,
     infobox: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1247,7 +1247,8 @@ export default {
                     qualiResults,
                     sprintResults,
                     raceResults,
-                    { fp1: fp1Results, fp2: fp2Results, fp3: fp3Results }
+                    { fp1: fp1Results, fp2: fp2Results, fp3: fp3Results },
+                    sprintQualiResults
                   );
                 }
 
@@ -1513,8 +1514,10 @@ export default {
                 title: string;
                 section: GpPageSection;
                 check: () => boolean;
+                sessionName?: string;
               }> = [
                 { header: "==Background==", title: "Background", section: 'background_report', check: () => isBackgroundTime },
+                { header: "=== Sprint Qualifying ===", title: "Sprint Qualifying", section: 'sprint_qualifying_report', sessionName: 'Sprint Qualifying', check: () => !!race.Sprint && isSprintQualiConcluded && !!sprintQualiResults && sprintQualiResults.length > 0 },
                 { header: "=== Q1 ===", title: "Q1", section: 'q1_report', check: () => isQualiConcluded && !!qualiResults && qualiResults.length > 0 },
                 { header: "=== Q2 ===", title: "Q2", section: 'q2_report', check: () => isQualiConcluded && !!qualiResults && qualiResults.length > 0 },
                 { header: "=== Q3 ===", title: "Q3", section: 'q3_report', check: () => isQualiConcluded && !!qualiResults && qualiResults.length > 0 },
@@ -1545,14 +1548,28 @@ export default {
                     driverStandings: prevDrivers || [],
                     constructorStandings: prevConstructors || []
                   };
-                  promptContext = generatePromptContext(race, drivers, standingsData, qualiResults, sprintResults, raceResults);
+                  promptContext = generatePromptContext(
+                    race,
+                    drivers,
+                    standingsData,
+                    qualiResults,
+                    sprintResults,
+                    raceResults,
+                    undefined,
+                    sprintQualiResults
+                  );
                 }
 
                 console.log(`Generating ${reportSectionsToGenerate.length} session reports in parallel...`);
                 const reports = await Promise.all(
                   reportSectionsToGenerate.map(async (sec) => {
                     try {
-                      const text = await generateReportForSection(env, sec.title, promptContext!);
+                      const text = await generateReportForSection(
+                        env,
+                        sec.title,
+                        promptContext!,
+                        sec.sessionName ? { year, racingKey, sessionName: sec.sessionName } : undefined
+                      );
                       return { sec, text };
                     } catch (err: any) {
                       console.error(`Failed to generate report for ${sec.title}:`, err.message);

--- a/src/llm-reporter.ts
+++ b/src/llm-reporter.ts
@@ -5,6 +5,7 @@ const SESSION_ARTICLE_KEYWORDS: Record<string, string[]> = {
   'FP1': ['fp1', 'free-practice-1', 'first-practice', 'practice-1', 'practice-one', 'free-practice-one'],
   'FP2': ['fp2', 'free-practice-2', 'second-practice', 'practice-2', 'practice-two', 'free-practice-two'],
   'FP3': ['fp3', 'free-practice-3', 'third-practice', 'practice-3', 'practice-three', 'free-practice-three'],
+  'Sprint Qualifying': ['sprint-qualifying', 'sprint-shootout', 'sprint-quali', 'sprint-qualifying-1', 'sq1'],
 };
 
 export async function appendKvWarning(kv: any, key: string, message: string): Promise<void> {
@@ -45,7 +46,8 @@ export function generatePromptContext(
     fp1?: Record<string, PracticeSessionData> | null;
     fp2?: Record<string, PracticeSessionData> | null;
     fp3?: Record<string, PracticeSessionData> | null;
-  }
+  },
+  sprintQualiResults?: any[]
 ): string {
   let context = `Race: ${race.season} Round ${race.round} - ${race.raceName}\n`;
   context += `Circuit: ${race.Circuit.circuitName} in ${race.Circuit.Location.locality}, ${race.Circuit.Location.country}\n\n`;
@@ -77,6 +79,23 @@ export function generatePromptContext(
     qualiResults.forEach((q, idx) => {
       const time = q.Q3 || q.Q2 || q.Q1 || 'No Time';
       context += `Pos ${idx + 1}: No. ${q.number} ${q.driver.givenName} ${q.driver.familyName} (${q.constructor.name}) - Time: ${time}\n`;
+    });
+    context += `\n`;
+  }
+
+  if (sprintQualiResults && sprintQualiResults.length > 0) {
+    context += `### Sprint Qualifying Results:\n`;
+    sprintQualiResults.forEach((q, idx) => {
+      const sq3 = q.Q3 || '';
+      const sq2 = q.Q2 || '';
+      const sq1 = q.Q1 || '';
+      const time = sq3 || sq2 || sq1 || 'No Time';
+      const segments = [
+        sq1 ? `SQ1: ${sq1}` : '',
+        sq2 ? `SQ2: ${sq2}` : '',
+        sq3 ? `SQ3: ${sq3}` : '',
+      ].filter(Boolean).join(', ');
+      context += `Pos ${idx + 1}: No. ${q.number} ${q.driver.givenName} ${q.driver.familyName} (${q.constructor.name}) - Best: ${time}${segments ? ` (${segments})` : ''}\n`;
     });
     context += `\n`;
   }
@@ -133,6 +152,19 @@ The "${sectionName}" section should summarize this free practice session:
 - Highlight any incidents, spins, mechanical issues, or driver feedback reported in the official session context.
 - Note any notable team or tyre performance trends visible from the results.
 - Describe any test driver appearances if relevant.`;
+  } else if (nameLower.includes("sprint qualifying") || nameLower === "sq1" || nameLower === "sq2" || nameLower === "sq3") {
+    const isSegment = nameLower === "sq1" || nameLower === "sq2" || nameLower === "sq3";
+    sectionInstructions = isSegment
+      ? `
+The "${sectionName}" section should summarize the events and eliminations in this segment of sprint qualifying:
+- Mention the top times and drivers.
+- List which drivers were eliminated in this session and the gap or circumstances, if visible.
+- Highlight the battle at the cutoff zone.`
+      : `
+The "Sprint Qualifying" section should summarize the full sprint qualifying session (SQ1, SQ2, and SQ3):
+- Mention the sprint pole position sitter and their fastest time.
+- Summarize eliminations and key battles in each segment (SQ1, SQ2, SQ3) based on the provided results.
+- Highlight notable gaps, incidents, or circumstances visible from the classification data.`;
   } else if (nameLower === "q1" || nameLower === "q2" || nameLower === "q3" || nameLower.includes("qualifying")) {
     sectionInstructions = `
 The "${sectionName}" section should summarize the events and eliminations in this segment of qualifying:

--- a/src/sync-kv.ts
+++ b/src/sync-kv.ts
@@ -17,6 +17,7 @@ export type GpPageSection =
   | 'q1_report'
   | 'q2_report'
   | 'q3_report'
+  | 'sprint_qualifying_report'
   | 'sprint_report'
   | 'race_report'
   | 'practice_results_fp1'
@@ -87,6 +88,7 @@ export const GP_PAGE_SECTIONS: GpPageSection[] = [
   'q1_report',
   'q2_report',
   'q3_report',
+  'sprint_qualifying_report',
   'sprint_report',
   'race_report',
   'practice_results_fp1',
@@ -161,6 +163,7 @@ export function gpPageSectionRequired(
     case 'q3_report':
       return isQualiConcluded;
     case 'sprint_qualifying':
+    case 'sprint_qualifying_report':
       return hasSprint && isSprintQualiConcluded;
     case 'sprint_results':
     case 'sprint_report':


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds LLM-powered report generation for the **Sprint Qualifying** section on sprint race weekend GP pages.

When sprint qualifying concludes and OpenF1 results are available, the cron worker now:
- Generates an encyclopedic report under `=== Sprint Qualifying ===`
- Includes SQ1/SQ2/SQ3 classification data in the LLM prompt context
- Optionally crawls the official F1.com sprint qualifying article for richer session detail
- Tracks sync state via a new `sprint_qualifying_report` KV flag (separate from the results table flag)

Human-edited content is preserved — the report is only written when the section is empty or a placeholder.

## Changes

- **`src/llm-reporter.ts`**: Sprint qualifying results in prompt context; dedicated prompt instructions; F1.com article keyword matching for Sprint Qualifying
- **`src/sync-kv.ts`**: New `sprint_qualifying_report` GP page section with required-when logic for concluded sprint qualifying
- **`src/index.ts`**: Wired Sprint Qualifying into the parallel LLM report generation pipeline
- **`scripts/verify-llm-reporter.ts`** / **`scripts/verify-sync-kv.ts`**: Test coverage for new behavior

## Test plan

- [x] `npm test` passes (TypeScript build + all verification scripts)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed1a70c-ed2b-4180-aeb7-9d2a9c75f099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed1a70c-ed2b-4180-aeb7-9d2a9c75f099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

