### PR TITLE
fix: Austrian GP test driver entry list and FP1 practice times

### DIFF
--- a/scripts/verify-entry-list-sync.ts
+++ b/scripts/verify-entry-list-sync.ts
@@ -171,7 +171,7 @@ const testDrivers2 = [{
 
 const updateWithBoth = updateEntryListTableIfNeeded(wikiPageWithTestDrivers, mainDrivers, testDrivers2);
 assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich');
-assert(updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should have preserved Patricio O\'Ward');
+assert(!updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should remove wiki-only test drivers when PDF list is authoritative');
 assert(updateWithBoth.updatedWikitext.includes('Felipe Drugovich'), 'Should have added Felipe Drugovich');
 
 console.log('PASS: Entry list verification and PDF test driver detection tests.');

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -174,4 +174,37 @@ const practiceNoPhantoms = generatePracticeWikitext(
 assert(!practiceNoPhantoms.includes('[[Paul Aron]]'), 'Should exclude test drivers without a classified session time');
 assert(practiceNoPhantoms.includes('[[Patricio O Ward]]'), 'Should still include participating test drivers');
 
+// Jolpica lists FP1 test drivers in the round driver entry; they must still appear in practice results
+const fp1TestDriverOnJolpicaList = {
+  driverId: 'ayumu_iwasa',
+  givenName: 'Ayumu',
+  familyName: 'Iwasa',
+  permanentNumber: '90',
+  nationality: 'Japanese',
+  code: 'IWA',
+  url: '',
+  dateOfBirth: '',
+};
+const driversWithJolpicaTestDriver = [...(mainDrivers as any[]), fp1TestDriverOnJolpicaList];
+const fp1WithIwasa = {
+  ...fp1WithTestDriver,
+  'Ayumu Iwasa': {
+    position: '15',
+    number: '90',
+    driverName: 'Ayumu Iwasa',
+    teamName: 'Racing Bulls',
+    time: '1:09.637',
+  },
+};
+const practiceWithJolpicaTestDriver = generatePracticeWikitext(
+  driversWithJolpicaTestDriver,
+  null,
+  fp1WithIwasa,
+  null,
+  null,
+  { hasSprint: true }
+);
+assert(practiceWithJolpicaTestDriver.includes('[[Ayumu Iwasa]]'), 'FP1 test driver should appear even when listed in Jolpica drivers');
+assert(practiceWithJolpicaTestDriver.includes('1:09.637'), 'FP1 test driver should keep classified session time');
+
 console.log('verify-practice-sessions: all assertions passed');

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ import {
   lookupTestDriverNationality,
   detectTestDriversFromPdf,
   updateEntryListTableIfNeeded,
+  buildRaceDriverKeys,
+  isRaceDriver,
 } from './wikitext-generator';
 import { 
   loginToWiki, 
@@ -1092,27 +1094,13 @@ export default {
               fp3Results = fp3;
 
               if (pdfText) {
-                const mainDriverKeys = new Set<string>();
-                for (const driver of drivers) {
-                  mainDriverKeys.add(driver.driverId.toLowerCase());
-                  mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
-                  mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
-                }
-
-                const isMainDriver = (name: string): boolean => {
-                  const lower = name.toLowerCase();
-                  const clean = lower.replace(/[\s'-]/g, '');
-                  return mainDriverKeys.has(lower) || mainDriverKeys.has(clean);
-                };
-
-                const isDriverInEntryList = (driverName: string): boolean =>
-                  isDriverListedInFiaPdf(driverName, pdfText!, drivers);
+                const raceDriverKeys = buildRaceDriverKeys(drivers);
 
                 const filterSessionResults = (sessionData: Record<string, PracticeSessionData> | null) => {
                   if (!sessionData) return;
                   for (const driverName of Object.keys(sessionData)) {
-                    if (!isMainDriver(driverName)) {
-                      if (!isDriverInEntryList(driverName)) {
+                    if (!isRaceDriver(driverName, raceDriverKeys)) {
+                      if (!isDriverListedInFiaPdf(driverName, pdfText!, drivers)) {
                         console.log(`Filtering out test driver ${driverName} from practice results because they are not on the FIA Entry List.`);
                         delete sessionData[driverName];
                       }

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -724,18 +724,9 @@ export function generatePracticeWikitext(
     ? buildDriverNameLookup(parseFiaEntryListPdf(options.pdfText, drivers).fp1TestDrivers)
     : null;
 
-  const mainDriverKeys = new Set<string>();
-  for (const driver of drivers) {
-    mainDriverKeys.add(driver.driverId.toLowerCase());
-    mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
-    mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
-  }
+  const raceDriverKeys = buildRaceDriverKeys(drivers);
 
-  const isMainDriver = (name: string): boolean => {
-    const lower = name.toLowerCase();
-    const clean = lower.replace(/[\s'-]/g, '');
-    return mainDriverKeys.has(lower) || mainDriverKeys.has(clean);
-  };
+  const isMainDriver = (name: string): boolean => isRaceDriver(name, raceDriverKeys);
 
   const enrichTestDriverData = (data: PracticeSessionData): PracticeSessionData => {
     if (!pdfTestDriverLookup) return data;
@@ -997,6 +988,24 @@ const DRIVER_TO_CONSTRUCTOR_2026: Record<string, string> = {
   "perez": "cadillac"
 };
 
+/** Name keys for the 22 race entrants (excludes FP1-only drivers Jolpica may list). */
+export function buildRaceDriverKeys(drivers: Driver[]): Set<string> {
+  const keys = new Set<string>();
+  for (const driver of drivers) {
+    if (!DRIVER_TO_CONSTRUCTOR_2026[driver.driverId]) continue;
+    keys.add(driver.driverId.toLowerCase());
+    keys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
+    keys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
+  }
+  return keys;
+}
+
+export function isRaceDriver(driverName: string, raceDriverKeys: Set<string>): boolean {
+  const lower = driverName.toLowerCase();
+  const clean = lower.replace(/[\s'-]/g, '');
+  return raceDriverKeys.has(lower) || raceDriverKeys.has(clean);
+}
+
 /** Resolve a driver's team wikitext, preferring quali data then the season roster map. */
 export function resolveDriverTeamTemplate(
   driverId: string,
@@ -1200,12 +1209,7 @@ export function detectTestDriversFromFp1(
     ? buildDriverNameLookup(parseFiaEntryListPdf(pdfText, mainDrivers).fp1TestDrivers)
     : null;
 
-  const mainDriverKeys = new Set<string>();
-  for (const driver of mainDrivers) {
-    mainDriverKeys.add(driver.driverId.toLowerCase());
-    mainDriverKeys.add(`${driver.givenName} ${driver.familyName}`.toLowerCase());
-    mainDriverKeys.add(`${driver.givenName}${driver.familyName}`.toLowerCase().replace(/[\s'-]/g, ''));
-  }
+  const raceDriverKeys = buildRaceDriverKeys(mainDrivers);
 
   const testDrivers: TestDriverEntry[] = [];
   const seen = new Set<string>();
@@ -1213,7 +1217,7 @@ export function detectTestDriversFromFp1(
   for (const data of Object.values(fp1)) {
     const name = data.driverName;
     const cleanName = name.toLowerCase().replace(/[\s'-]/g, '');
-    if (mainDriverKeys.has(name.toLowerCase()) || mainDriverKeys.has(cleanName)) {
+    if (isRaceDriver(name, raceDriverKeys)) {
       continue;
     }
     if (seen.has(cleanName)) continue;
@@ -1412,8 +1416,11 @@ export function updateEntryListTableIfNeeded(
   }
 
   const combinedTestDriversMap = new Map<string, TestDriverEntry>();
-  parsedTestDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
-  testDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  if (testDrivers.length > 0) {
+    testDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  } else {
+    parsedTestDrivers.forEach(td => combinedTestDriversMap.set(td.name.toLowerCase(), td));
+  }
   const combinedTestDrivers = Array.from(combinedTestDriversMap.values())
     .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problems

On the [2026 Austrian Grand Prix](https://f1.fandom.com/wiki/2026_Austrian_Grand_Prix) page after the latest cron update:

1. **Patricio O'Ward (#98)** remained in the "Test Drivers for Practice 1" entry list subsection even though he is not on the official FIA entry list PDF for Austria.
2. **FP1 test drivers had no times** in the practice results table (all DNP), despite having classified FP1 sessions on F1.com.

## Root causes

1. **Entry list**: `updateEntryListTableIfNeeded` merged wiki-parsed test drivers with PDF-detected ones, preserving stale wiki-only drivers like O'Ward.
2. **Practice results**: Jolpica returns 28 drivers for round 8 (22 race entrants + 6 FP1 test drivers). The code treated all Jolpica drivers as "main drivers", so FP1 test drivers were excluded from `collectTestDrivers` but also not in `DRIVER_TO_CONSTRUCTOR_2026`, making them invisible in the practice table.

## Fixes

- When PDF test drivers are provided, use the **FIA PDF as the sole source of truth** for the test driver subsection (removes wiki-only drivers).
- Introduce `buildRaceDriverKeys()` / `isRaceDriver()` using only the 22 `DRIVER_TO_CONSTRUCTOR_2026` entrants, so Jolpica-listed FP1 test drivers are correctly classified for practice results.

## Verification

Reproduced locally against the live Austrian GP FP1 scrape + FIA entry list PDF:
- All 6 FP1 test drivers now appear with correct numbers, flags, and FP1 times (e.g. Iwasa `1:09.637` P15)
- O'Ward is dropped when PDF test driver list is authoritative

Regression tests added in `verify-practice-sessions.ts` and `verify-entry-list-sync.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce4ef750-ba7e-4b96-acfb-34d40dda39fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce4ef750-ba7e-4b96-acfb-34d40dda39fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

