### PR TITLE
feat: Jolpi.ca-first test drivers and OpenF1 practice results

### DIFF
--- a/scripts/verify-entry-list-sync.ts
+++ b/scripts/verify-entry-list-sync.ts
@@ -4,6 +4,8 @@
  */
 import {
   detectTestDriversFromPdf,
+  detectTestDriversFromJolpica,
+  resolveTestDriversForRace,
   updateEntryListTableIfNeeded,
   extractEntryListTable
 } from '../src/wikitext-generator';
@@ -171,7 +173,36 @@ const testDrivers2 = [{
 
 const updateWithBoth = updateEntryListTableIfNeeded(wikiPageWithTestDrivers, mainDrivers, testDrivers2);
 assert(updateWithBoth.changed === true, 'Should update to add Felipe Drugovich');
-assert(!updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should remove wiki-only test drivers when PDF list is authoritative');
+assert(!updateWithBoth.updatedWikitext.includes('Patricio O\'Ward'), 'Should remove wiki-only test drivers when authoritative list is provided');
 assert(updateWithBoth.updatedWikitext.includes('Felipe Drugovich'), 'Should have added Felipe Drugovich');
+
+// --- 5. Jolpica-first test driver detection ---
+const jolpicaDrivers: Driver[] = [
+  ...mainDrivers,
+  {
+    driverId: 'drugovich',
+    givenName: 'Felipe',
+    familyName: 'Drugovich',
+  } as Driver,
+  {
+    driverId: 'iwasa',
+    givenName: 'Ayumu',
+    familyName: 'Iwasa',
+  } as Driver,
+];
+
+const jolpicaTestDrivers = detectTestDriversFromJolpica(jolpicaDrivers);
+assert(jolpicaTestDrivers.length === 2, `Expected 2 Jolpica test drivers, got ${jolpicaTestDrivers.length}`);
+assert(jolpicaTestDrivers.some(td => td.name === 'Felipe Drugovich'), 'Should detect Drugovich from Jolpica');
+assert(jolpicaTestDrivers.some(td => td.name === 'Ayumu Iwasa'), 'Should detect Iwasa from Jolpica');
+
+const resolvedFromJolpica = resolveTestDriversForRace(jolpicaDrivers, { pdfText: mockPdfText });
+assert(resolvedFromJolpica.length === 2, 'Jolpica should win over PDF-only rows');
+assert(resolvedFromJolpica.find(td => td.name === 'Felipe Drugovich')?.number === '34', 'PDF should enrich Jolpica test driver number');
+assert(resolvedFromJolpica.find(td => td.name === 'Felipe Drugovich')?.constructorId === 'aston_martin', 'PDF should enrich Jolpica test driver team');
+
+const resolvedPdfFallback = resolveTestDriversForRace(mainDrivers, { pdfText: mockPdfText });
+assert(resolvedPdfFallback.length === 1, 'Should fall back to PDF when Jolpica has no extra drivers');
+assert(resolvedPdfFallback[0].name === 'Felipe Drugovich', 'PDF fallback should return Drugovich');
 
 console.log('PASS: Entry list verification and PDF test driver detection tests.');

--- a/scripts/verify-openf1-sync.ts
+++ b/scripts/verify-openf1-sync.ts
@@ -2,10 +2,13 @@ import {
   createF1ApiContext,
   fetchOpenF1Json,
   fetchRoundJolpicaData,
+  formatOpenF1PracticeTime,
   formatOpenF1SessionSegmentTime,
   formatOpenF1Time,
   getDriverStandings,
+  getOpenF1PracticeSessionResult,
   getOpenF1SprintQualifyingResult,
+  matchOpenF1PracticeSession,
   matchOpenF1SprintQualifyingSession,
   OpenF1Session,
 } from '../src/f1-api';
@@ -87,6 +90,41 @@ async function main(): Promise<void> {
     matchOpenF1SprintQualifyingSession(sampleSessions, miamiRace, 6)?.session_key === 10024,
     'Miami GP matches Miami session'
   );
+
+  // 3b. Practice session matching
+  console.log('Testing matchOpenF1PracticeSession...');
+  const practiceSessions: OpenF1Session[] = [
+    {
+      session_key: 11308,
+      session_name: 'Practice 1',
+      date_start: '2026-06-26T11:30:00+00:00',
+      circuit_short_name: 'Spielberg',
+    },
+    {
+      session_key: 11309,
+      session_name: 'Practice 2',
+      date_start: '2026-06-26T15:30:00+00:00',
+      circuit_short_name: 'Spielberg',
+    },
+  ];
+  const austriaRace = {
+    round: '8',
+    date: '2026-06-28',
+    raceName: 'Austrian Grand Prix',
+    Circuit: { circuitId: 'red_bull_ring' },
+    FirstPractice: { date: '2026-06-26', time: '11:30:00Z' },
+    SecondPractice: { date: '2026-06-26', time: '15:30:00Z' },
+  };
+  assert(
+    matchOpenF1PracticeSession(practiceSessions, austriaRace, 8, 1)?.session_key === 11308,
+    'Austria FP1 matches Spielberg session'
+  );
+  assert(
+    matchOpenF1PracticeSession(practiceSessions, austriaRace, 8, 2)?.session_key === 11309,
+    'Austria FP2 matches Spielberg session'
+  );
+  assert(formatOpenF1PracticeTime({ duration: 67.796, dns: false, dsq: false }) === '1:07.796', 'Practice time format');
+  assert(formatOpenF1PracticeTime({ duration: null, dns: true, dsq: false }) === 'DNS', 'Practice DNS format');
 
   // 4. Test generateSprintQualifyingWikitext
   console.log('Testing generateSprintQualifyingWikitext...');
@@ -197,6 +235,24 @@ async function main(): Promise<void> {
     assert(
       integrationCtx.apiCallCount <= 8,
       'Reusing ctx cache does not add network calls for session/results'
+    );
+
+    const austriaFp1 = await getOpenF1PracticeSessionResult(
+      2026,
+      8,
+      austriaRace,
+      1,
+      roundData.drivers,
+      integrationCtx
+    );
+    assert(austriaFp1 !== null && Object.keys(austriaFp1).length >= 20, 'Austria 2026 FP1 returns practice results');
+    assert(
+      Object.values(austriaFp1!).some(r => r.driverName.includes('Iwasa')),
+      'Austria FP1 includes test driver Ayumu Iwasa'
+    );
+    assert(
+      Object.values(austriaFp1!).some(r => r.time === '1:07.796'),
+      'Austria FP1 pole time formatted from OpenF1 duration'
     );
   } catch (error: any) {
     console.log(`SKIP: OpenF1 live integration tests (${error?.message || error})`);

--- a/scripts/verify-practice-sessions.ts
+++ b/scripts/verify-practice-sessions.ts
@@ -9,6 +9,7 @@ import {
   findEntryListHeadingIndex,
   generatePracticeWikitext,
   resolveDriverTeamTemplate,
+  resolveTestDriversForRace,
 } from '../src/wikitext-generator';
 import { gpPageSectionRequired } from '../src/sync-kv';
 
@@ -206,5 +207,9 @@ const practiceWithJolpicaTestDriver = generatePracticeWikitext(
 );
 assert(practiceWithJolpicaTestDriver.includes('[[Ayumu Iwasa]]'), 'FP1 test driver should appear even when listed in Jolpica drivers');
 assert(practiceWithJolpicaTestDriver.includes('1:09.637'), 'FP1 test driver should keep classified session time');
+
+const resolvedAustriaStyle = resolveTestDriversForRace(driversWithJolpicaTestDriver as any, { fp1: fp1WithIwasa });
+assert(resolvedAustriaStyle.some(td => td.name === 'Ayumu Iwasa'), 'Jolpica-first resolver should include Iwasa');
+assert(!resolvedAustriaStyle.some(td => td.name === 'Patricio O Ward'), 'FP1-only drivers not on Jolpica should not be added to entry list');
 
 console.log('verify-practice-sessions: all assertions passed');

--- a/src/f1-api-cache.ts
+++ b/src/f1-api-cache.ts
@@ -30,6 +30,8 @@ export interface CachedScheduleRace {
   Qualifying?: { date: string; time?: string };
   Sprint?: { date: string; time?: string };
   FirstPractice?: { date: string; time?: string };
+  SecondPractice?: { date: string; time?: string };
+  ThirdPractice?: { date: string; time?: string };
   SprintQualifying?: { date: string; time?: string };
 }
 

--- a/src/f1-api.ts
+++ b/src/f1-api.ts
@@ -1088,3 +1088,201 @@ export async function getOpenF1SprintQualifyingResult(
   });
 }
 
+export interface OpenF1PracticeSessionResult {
+  position: number;
+  driver_number: number;
+  duration?: number | null;
+  gap_to_leader?: number | null;
+  dns: boolean;
+  dnf: boolean;
+  dsq: boolean;
+}
+
+export interface OpenF1SessionDriver {
+  driver_number: number;
+  full_name: string;
+  first_name: string;
+  last_name: string;
+  team_name: string;
+  name_acronym: string;
+}
+
+function getPracticeSessionTargetDate(
+  race: CachedScheduleRace,
+  sessionNumber: 1 | 2 | 3
+): string {
+  if (sessionNumber === 1 && race.FirstPractice?.date) return race.FirstPractice.date;
+  if (sessionNumber === 2 && race.SecondPractice?.date) return race.SecondPractice.date;
+  if (sessionNumber === 3 && race.ThirdPractice?.date) return race.ThirdPractice.date;
+  return race.date;
+}
+
+/** Pick the closest OpenF1 Practice session for a race weekend (exported for tests). */
+export function matchOpenF1PracticeSession(
+  sessions: OpenF1Session[],
+  race: CachedScheduleRace,
+  round: number,
+  sessionNumber: 1 | 2 | 3
+): OpenF1Session | undefined {
+  const sessionName = `Practice ${sessionNumber}`;
+  const namedSessions = sessions.filter(s => s.session_name === sessionName);
+  if (namedSessions.length === 0) return undefined;
+
+  const targetDateStr = getPracticeSessionTargetDate(race, sessionNumber);
+  const targetDate = new Date(`${targetDateStr}T12:00:00Z`);
+  const circuitId = race.Circuit?.circuitId;
+
+  let candidates = namedSessions;
+  if (circuitId) {
+    const byCircuit = namedSessions.filter(session =>
+      session.circuit_short_name && circuitsMatch(circuitId, session.circuit_short_name)
+    );
+    if (byCircuit.length > 0) {
+      candidates = byCircuit;
+    }
+  }
+
+  let best: OpenF1Session | undefined;
+  let bestDiffMs = Infinity;
+  for (const session of candidates) {
+    const sessionDate = new Date(session.date_start);
+    const diffMs = Math.abs(sessionDate.getTime() - targetDate.getTime());
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    if (diffDays <= OPENF1_SESSION_MATCH_WINDOW_DAYS && diffMs < bestDiffMs) {
+      best = session;
+      bestDiffMs = diffMs;
+    }
+  }
+
+  if (!best) {
+    const raceName = race.raceName || 'Unknown';
+    console.warn(`No matching OpenF1 ${sessionName} session found for round ${round} (${raceName})`);
+  }
+  return best;
+}
+
+export function formatOpenF1PracticeTime(result: Pick<OpenF1PracticeSessionResult, 'duration' | 'dns' | 'dsq'>): string {
+  if (result.dns) return 'DNS';
+  if (result.dsq) return 'DSQ';
+  if (result.duration === null || result.duration === undefined) return '';
+  return formatOpenF1Time(result.duration);
+}
+
+function titleCaseWord(word: string): string {
+  if (!word) return word;
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function resolveOpenF1DriverName(
+  driverNumber: number,
+  sessionDriver: OpenF1SessionDriver | undefined,
+  drivers: Driver[]
+): string {
+  const numStr = driverNumber.toString();
+  const jolpicaDriver = drivers.find(d => d.permanentNumber === numStr);
+  if (jolpicaDriver) {
+    return `${jolpicaDriver.givenName} ${jolpicaDriver.familyName}`;
+  }
+  if (sessionDriver) {
+    return `${titleCaseWord(sessionDriver.first_name)} ${titleCaseWord(sessionDriver.last_name)}`;
+  }
+  return `Driver #${numStr}`;
+}
+
+export function convertOpenF1PracticeResults(
+  results: OpenF1PracticeSessionResult[],
+  sessionDrivers: OpenF1SessionDriver[],
+  drivers: Driver[]
+): Record<string, PracticeSessionData> {
+  const driverByNumber = new Map(sessionDrivers.map(d => [d.driver_number, d]));
+  const parsed: Record<string, PracticeSessionData> = {};
+
+  for (const result of results) {
+    const sessionDriver = driverByNumber.get(result.driver_number);
+    const driverName = resolveOpenF1DriverName(result.driver_number, sessionDriver, drivers);
+    parsed[driverName] = {
+      position: result.position.toString(),
+      number: result.driver_number.toString(),
+      driverName,
+      teamName: sessionDriver?.team_name || '',
+      time: formatOpenF1PracticeTime(result),
+    };
+  }
+
+  return mapDriverNames(parsed, drivers);
+}
+
+export async function getOpenF1PracticeSessionResult(
+  year: number,
+  round: number,
+  race: CachedScheduleRace,
+  sessionNumber: 1 | 2 | 3,
+  drivers: Driver[],
+  ctx?: F1ApiContext
+): Promise<Record<string, PracticeSessionData> | null> {
+  const sessionName = encodeURIComponent(`Practice ${sessionNumber}`);
+  const sessionsUrl = `https://api.openf1.org/v1/sessions?session_name=${sessionName}&year=${year}`;
+  const sessions = await fetchOpenF1Json<OpenF1Session[]>(sessionsUrl, ctx, 86400 * 7);
+
+  if (!sessions || sessions.length === 0) {
+    console.warn(`No OpenF1 ${sessionName} sessions found for year ${year}`);
+    return null;
+  }
+
+  const matchedSession = matchOpenF1PracticeSession(sessions, race, round, sessionNumber);
+  if (!matchedSession) return null;
+
+  const raceName = race.raceName || 'Unknown';
+  console.log(`Matched OpenF1 ${sessionName} session_key ${matchedSession.session_key} for ${raceName}`);
+
+  const [results, sessionDrivers] = await Promise.all([
+    fetchOpenF1Json<OpenF1PracticeSessionResult[]>(
+      `https://api.openf1.org/v1/session_result?session_key=${matchedSession.session_key}`,
+      ctx,
+      86400
+    ),
+    fetchOpenF1Json<OpenF1SessionDriver[]>(
+      `https://api.openf1.org/v1/drivers?session_key=${matchedSession.session_key}`,
+      ctx,
+      86400
+    ),
+  ]);
+
+  if (!results || results.length === 0) {
+    console.warn(`No OpenF1 practice results found for session_key ${matchedSession.session_key}`);
+    return null;
+  }
+
+  results.sort((a, b) => a.position - b.position);
+  return convertOpenF1PracticeResults(results, sessionDrivers ?? [], drivers);
+}
+
+/** Fetch practice results from OpenF1, falling back to F1.com scraping when unavailable. */
+export async function getPracticeSessionWithFallback(
+  year: number,
+  round: number,
+  raceName: string,
+  race: CachedScheduleRace,
+  sessionNumber: 1 | 2 | 3,
+  drivers: Driver[],
+  ctx?: F1ApiContext
+): Promise<Record<string, PracticeSessionData> | null> {
+  try {
+    const openF1Results = await getOpenF1PracticeSessionResult(year, round, race, sessionNumber, drivers, ctx);
+    if (openF1Results && Object.keys(openF1Results).length > 0) {
+      return openF1Results;
+    }
+  } catch (e: any) {
+    console.warn(`OpenF1 Practice ${sessionNumber} fetch failed for round ${round}: ${e.message}`);
+  }
+
+  const url = buildPracticeSessionUrl(year, round, raceName, sessionNumber);
+  console.log(`Falling back to F1.com scrape for Practice ${sessionNumber}: ${url}`);
+  try {
+    return await scrapePracticeSession(url, drivers);
+  } catch (e: any) {
+    console.warn(`F1.com Practice ${sessionNumber} scrape failed for round ${round}: ${e.message}`);
+    return null;
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   getConstructorStandings,
   getDriversForRaceWithFallback,
   scrapePracticeSession,
+  getPracticeSessionWithFallback,
   parsePracticeHTML,
   mapDriverNames,
   fetchOfficialRaceName,
@@ -41,10 +42,13 @@ import {
   getTeamTemplate,
   detectTestDriversFromFp1,
   lookupTestDriverNationality,
-  detectTestDriversFromPdf,
-  updateEntryListTableIfNeeded,
+  detectTestDriversFromJolpica,
+  resolveTestDriversForRace,
   buildRaceDriverKeys,
   isRaceDriver,
+  buildTestDriverNameKeys,
+  isKnownTestDriver,
+  updateEntryListTableIfNeeded,
 } from './wikitext-generator';
 import { 
   loginToWiki, 
@@ -308,18 +312,32 @@ export default {
           return corsResponse({ wikitext, fp1: mapped });
         }
 
-        // Auto Scraping
-        if (!fp1Url) return corsResponse({ error: 'Practice URL required' }, 400);
+        // Auto fetch: OpenF1 primary, F1.com URL scrape fallback
+        const schedule = await getSchedule(yr, apiCtx).catch(() => []);
+        const race = schedule.find(r => parseInt(r.round, 10) === rd);
+        const raceName = race?.raceName || 'Grand Prix';
 
-        const fp2Url = fp1Url.replace('/practice/1', '/practice/2');
-        const fp3Url = fp1Url.replace('/practice/1', '/practice/3');
+        let fp1: Record<string, PracticeSessionData> | null = null;
+        let fp2: Record<string, PracticeSessionData> | null = null;
+        let fp3: Record<string, PracticeSessionData> | null = null;
 
-        // Scrape sessions concurrently but catch individual failures gracefully
-        const [fp1, fp2, fp3] = await Promise.all([
-          scrapePracticeSession(fp1Url, drivers).catch(() => null),
-          scrapePracticeSession(fp2Url, drivers).catch(() => null),
-          scrapePracticeSession(fp3Url, drivers).catch(() => null),
-        ]);
+        if (race) {
+          [fp1, fp2, fp3] = await Promise.all([
+            getPracticeSessionWithFallback(yr, rd, raceName, race, 1, drivers, apiCtx).catch(() => null),
+            getPracticeSessionWithFallback(yr, rd, raceName, race, 2, drivers, apiCtx).catch(() => null),
+            getPracticeSessionWithFallback(yr, rd, raceName, race, 3, drivers, apiCtx).catch(() => null),
+          ]);
+        } else if (fp1Url) {
+          const fp2Url = fp1Url.replace('/practice/1', '/practice/2');
+          const fp3Url = fp1Url.replace('/practice/1', '/practice/3');
+          [fp1, fp2, fp3] = await Promise.all([
+            scrapePracticeSession(fp1Url, drivers).catch(() => null),
+            scrapePracticeSession(fp2Url, drivers).catch(() => null),
+            scrapePracticeSession(fp3Url, drivers).catch(() => null),
+          ]);
+        } else {
+          return corsResponse({ error: 'Practice URL required when race schedule is unavailable' }, 400);
+        }
 
         const wikitext = generatePracticeWikitext(drivers, qualiResults, fp1, fp2, fp3);
 
@@ -1038,9 +1056,15 @@ export default {
             let fp2Results: Record<string, PracticeSessionData> | null = null;
             let fp3Results: Record<string, PracticeSessionData> | null = null;
 
-            // Fetch and parse the FIA entry list PDF if available (shared between entry list sync and practice filtering)
+            // Fetch and parse the FIA entry list PDF when Jolpica has no test drivers or metadata needs enrichment
             let pdfText: string | null = null;
-            if (needPracticeScrape || needEntryList) {
+            const fetchPdfIfNeeded = async (driversForPdf: typeof drivers) => {
+              if (pdfText !== null) return pdfText;
+              const jolpicaTestDrivers = detectTestDriversFromJolpica(driversForPdf);
+              const needsPdf =
+                jolpicaTestDrivers.length === 0 ||
+                jolpicaTestDrivers.some(td => !td.number || td.flag === '{{FIA}}' || !td.constructorId);
+              if (!needsPdf) return null;
               try {
                 console.log(`Fetching FIA entry list PDF for ${year} ${raceName}...`);
                 pdfText = await fetchFiaEntryListText(year, raceName);
@@ -1052,16 +1076,18 @@ export default {
               } catch (e: any) {
                 console.error(`Error parsing FIA entry list PDF: ${e.message}`);
               }
-            }
+              return pdfText;
+            };
 
             // --- 1. Verify and Sync Entry List ---
             if (needEntryList && !isNewPage) {
               if (drivers.length === 0) {
                 drivers = await getDriversForRaceWithFallback(year, round, apiCtx);
               }
-              const pdfTestDrivers = pdfText ? detectTestDriversFromPdf(pdfText, drivers) : [];
+              await fetchPdfIfNeeded(drivers);
+              const resolvedTestDrivers = resolveTestDriversForRace(drivers, { pdfText });
               console.log(`Verifying/updating Entry List table for ${gpPageTitle}...`);
-              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, pdfTestDrivers);
+              const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, resolvedTestDrivers);
               if (entryListUpdate.changed) {
                 updatedContent = entryListUpdate.updatedWikitext;
                 changes.push("Entry List");
@@ -1079,13 +1105,13 @@ export default {
 
               const [fp1, fp2, fp3] = await Promise.all([
                 needFp1
-                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 1), drivers).catch(() => null)
+                  ? getPracticeSessionWithFallback(year, round, raceName, race, 1, drivers, apiCtx).catch(() => null)
                   : Promise.resolve(null),
                 needFp2
-                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 2), drivers).catch(() => null)
+                  ? getPracticeSessionWithFallback(year, round, raceName, race, 2, drivers, apiCtx).catch(() => null)
                   : Promise.resolve(null),
                 needFp3
-                  ? scrapePracticeSession(buildPracticeSessionUrl(year, round, raceName, 3), drivers).catch(() => null)
+                  ? getPracticeSessionWithFallback(year, round, raceName, race, 3, drivers, apiCtx).catch(() => null)
                   : Promise.resolve(null),
               ]);
 
@@ -1093,25 +1119,29 @@ export default {
               fp2Results = fp2;
               fp3Results = fp3;
 
-              if (pdfText) {
-                const raceDriverKeys = buildRaceDriverKeys(drivers);
+              await fetchPdfIfNeeded(drivers);
+              const resolvedTestDrivers = resolveTestDriversForRace(drivers, { pdfText, fp1: fp1Results });
+              const testDriverKeys = buildTestDriverNameKeys(resolvedTestDrivers);
+              const raceDriverKeys = buildRaceDriverKeys(drivers);
 
-                const filterSessionResults = (sessionData: Record<string, PracticeSessionData> | null) => {
-                  if (!sessionData) return;
-                  for (const driverName of Object.keys(sessionData)) {
-                    if (!isRaceDriver(driverName, raceDriverKeys)) {
-                      if (!isDriverListedInFiaPdf(driverName, pdfText!, drivers)) {
-                        console.log(`Filtering out test driver ${driverName} from practice results because they are not on the FIA Entry List.`);
-                        delete sessionData[driverName];
-                      }
+              const filterSessionResults = (sessionData: Record<string, PracticeSessionData> | null) => {
+                if (!sessionData) return;
+                for (const driverName of Object.keys(sessionData)) {
+                  if (!isRaceDriver(driverName, raceDriverKeys)) {
+                    const knownTestDriver =
+                      isKnownTestDriver(driverName, testDriverKeys) ||
+                      (pdfText ? isDriverListedInFiaPdf(driverName, pdfText, drivers) : false);
+                    if (!knownTestDriver) {
+                      console.log(`Filtering out test driver ${driverName} from practice results because they are not on the entry list.`);
+                      delete sessionData[driverName];
                     }
                   }
-                };
+                }
+              };
 
-                filterSessionResults(fp1Results);
-                filterSessionResults(fp2Results);
-                filterSessionResults(fp3Results);
-              }
+              filterSessionResults(fp1Results);
+              filterSessionResults(fp2Results);
+              filterSessionResults(fp3Results);
 
               const hasAnyPracticeData =
                 (fp1Results && Object.keys(fp1Results).length > 0) ||
@@ -1156,9 +1186,9 @@ export default {
               }
 
               if (needFp1 && fp1Results && Object.keys(fp1Results).length > 0) {
-                const testDrivers = detectTestDriversFromFp1(drivers, fp1Results, pdfText);
-                if (testDrivers.length > 0) {
-                  for (const td of testDrivers) {
+                const fp1TestDrivers = resolveTestDriversForRace(drivers, { pdfText, fp1: fp1Results });
+                if (fp1TestDrivers.length > 0) {
+                  for (const td of fp1TestDrivers) {
                     if (!lookupTestDriverNationality(td.name)) {
                       await appendKvWarning(
                         env.F1_WIKI_STATE,
@@ -1168,7 +1198,7 @@ export default {
                     }
                   }
                   console.log(`Safely merging FP1 test drivers into Entry List table for ${gpPageTitle}...`);
-                  const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, testDrivers);
+                  const entryListUpdate = updateEntryListTableIfNeeded(updatedContent, drivers, fp1TestDrivers);
                   if (entryListUpdate.changed) {
                     updatedContent = entryListUpdate.updatedWikitext;
                     changes.push("Entry List (Test Drivers)");

--- a/src/wikitext-generator.ts
+++ b/src/wikitext-generator.ts
@@ -1006,6 +1006,120 @@ export function isRaceDriver(driverName: string, raceDriverKeys: Set<string>): b
   return raceDriverKeys.has(lower) || raceDriverKeys.has(clean);
 }
 
+export function buildTestDriverNameKeys(testDrivers: TestDriverEntry[]): Set<string> {
+  const keys = new Set<string>();
+  for (const td of testDrivers) {
+    keys.add(td.name.toLowerCase());
+    keys.add(td.name.toLowerCase().replace(/[\s'-]/g, ''));
+  }
+  return keys;
+}
+
+export function isKnownTestDriver(driverName: string, testDriverKeys: Set<string>): boolean {
+  const lower = driverName.toLowerCase();
+  const clean = lower.replace(/[\s'-]/g, '');
+  return testDriverKeys.has(lower) || testDriverKeys.has(clean);
+}
+
+function driverNameKeys(name: string): string[] {
+  const lower = name.toLowerCase();
+  return [lower, lower.replace(/[\s'-]/g, '')];
+}
+
+function lookupFp1PracticeData(
+  name: string,
+  fp1: Record<string, PracticeSessionData> | null | undefined
+): PracticeSessionData | undefined {
+  if (!fp1) return undefined;
+  const keys = new Set(driverNameKeys(name));
+  for (const data of Object.values(fp1)) {
+    for (const key of driverNameKeys(data.driverName)) {
+      if (keys.has(key)) return data;
+    }
+  }
+  return undefined;
+}
+
+/** Test drivers listed in Jolpica round entry but not in the season race roster. */
+export function detectTestDriversFromJolpica(drivers: Driver[]): TestDriverEntry[] {
+  return drivers
+    .filter(driver => !DRIVER_TO_CONSTRUCTOR_2026[driver.driverId])
+    .map(driver => {
+      const name = `${driver.givenName} ${driver.familyName}`;
+      const nationality = driver.nationality || lookupTestDriverNationality(name);
+      return {
+        number: driver.permanentNumber || '',
+        name,
+        flag: nationality ? getFlag(nationality) : '{{FIA}}',
+        constructorId: '',
+      };
+    })
+    .sort((a, b) => parseInt(a.number || '999', 10) - parseInt(b.number || '999', 10));
+}
+
+function enrichTestDriverEntry(
+  entry: TestDriverEntry,
+  pdfLookup: Map<string, FiaDriverRow> | null,
+  fp1?: Record<string, PracticeSessionData> | null
+): TestDriverEntry {
+  let number = entry.number;
+  let flag = entry.flag;
+  let constructorId = entry.constructorId;
+
+  for (const key of driverNameKeys(entry.name)) {
+    const pdfRow = pdfLookup?.get(key);
+    if (pdfRow) {
+      number = pdfRow.number || number;
+      flag = getFlagFromNatCode(pdfRow.natCode) || flag;
+      constructorId =
+        teamNameToConstructorId(pdfRow.team) ||
+        teamNameToConstructorId(pdfRow.constructor) ||
+        constructorId;
+      break;
+    }
+  }
+
+  const fp1Data = lookupFp1PracticeData(entry.name, fp1);
+  if (fp1Data) {
+    number = number || fp1Data.number;
+    constructorId = constructorId || teamNameToConstructorId(fp1Data.teamName) || '';
+  }
+
+  if (flag === '{{FIA}}') {
+    const nationality = lookupTestDriverNationality(entry.name);
+    if (nationality) flag = getFlag(nationality);
+  }
+
+  return { ...entry, number, flag, constructorId };
+}
+
+/**
+ * Resolve FP1 test drivers: Jolpica round entry first, FIA PDF fallback, enriched by PDF/FP1 metadata.
+ */
+export function resolveTestDriversForRace(
+  drivers: Driver[],
+  options?: {
+    pdfText?: string | null;
+    fp1?: Record<string, PracticeSessionData> | null;
+  }
+): TestDriverEntry[] {
+  const pdfLookup = options?.pdfText
+    ? buildDriverNameLookup(parseFiaEntryListPdf(options.pdfText, drivers).fp1TestDrivers)
+    : null;
+
+  const jolpicaTestDrivers = detectTestDriversFromJolpica(drivers);
+  const base =
+    jolpicaTestDrivers.length > 0
+      ? jolpicaTestDrivers
+      : options?.pdfText
+        ? detectTestDriversFromPdf(options.pdfText, drivers)
+        : [];
+
+  return base
+    .map(entry => enrichTestDriverEntry(entry, pdfLookup, options?.fp1))
+    .sort((a, b) => parseInt(a.number || '999', 10) - parseInt(b.number || '999', 10));
+}
+
 /** Resolve a driver's team wikitext, preferring quali data then the season roster map. */
 export function resolveDriverTeamTemplate(
   driverId: string,
@@ -1364,6 +1478,8 @@ export function updateEntryListTableIfNeeded(
   const parsedTestDrivers: TestDriverEntry[] = [];
   const cleanContent = tableInfo.content.replace(/\|\}/g, '').trim();
   const rows = cleanContent.split(/\r?\n\|-\r?\n/);
+  const raceDrivers = expectedDrivers.filter(d => DRIVER_TO_CONSTRUCTOR_2026[d.driverId]);
+  const raceDriverKeys = buildRaceDriverKeys(raceDrivers);
   
   for (let i = 1; i < rows.length; i++) {
     const row = rows[i];
@@ -1390,10 +1506,7 @@ export function updateEntryListTableIfNeeded(
     }
 
     if (number && name) {
-      const isMain = expectedDrivers.some(d => {
-        const mainName = `${d.givenName} ${d.familyName}`.toLowerCase();
-        return mainName === name.toLowerCase();
-      });
+      const isMain = isRaceDriver(name, raceDriverKeys);
       if (!isMain) {
         let constructorId = '';
         for (const line of lines) {
@@ -1425,7 +1538,7 @@ export function updateEntryListTableIfNeeded(
     .sort((a, b) => parseInt(a.number, 10) - parseInt(b.number, 10));
 
   let entryListRows = "";
-  const sortedDrivers = [...expectedDrivers].sort((a, b) => {
+  const sortedDrivers = [...raceDrivers].sort((a, b) => {
     const numA = parseInt(a.permanentNumber || '0', 10);
     const numB = parseInt(b.permanentNumber || '0', 10);
     return numA - numB;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on merged PR #31 and switches test-driver and practice-data sourcing to API-first flows:

- **Test drivers:** Jolpica round driver list is the primary source; FIA PDF is used only for fallback/enrichment (numbers, flags, teams).
- **Practice results:** OpenF1 `session_result` is the primary source; F1.com HTML scraping remains as fallback.

## Changes

### Jolpica-first test drivers
- Add `detectTestDriversFromJolpica()` and `resolveTestDriversForRace()` in `wikitext-generator.ts`
- Lazy-fetch FIA PDF only when Jolpica has no test drivers or metadata is incomplete
- Entry list sync uses authoritative resolved test driver list (removes stale wiki-only drivers like O'Ward)
- Practice filtering validates against Jolpica-resolved test drivers (+ PDF fallback)

### OpenF1 practice results
- Add `getOpenF1PracticeSessionResult()`, `matchOpenF1PracticeSession()`, and `getPracticeSessionWithFallback()` in `f1-api.ts`
- Cron worker and `/api/scrape-practice` now use OpenF1 first, F1.com scrape on failure
- Verified against live Austria 2026 FP1 (`session_key=11308`) including test driver Ayumu Iwasa

## Testing

- `npx tsx scripts/verify-entry-list-sync.ts`
- `npx tsx scripts/verify-practice-sessions.ts`
- `npx tsx scripts/verify-openf1-sync.ts` (includes live OpenF1 Austria FP1 check)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce4ef750-ba7e-4b96-acfb-34d40dda39fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce4ef750-ba7e-4b96-acfb-34d40dda39fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

